### PR TITLE
Boot WAL at startup and gate readiness on durability state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **If an implementation is incorrect, FIX IT! Do NOT modify tests to match broken code.**
 
+## Beads Coordination Rules
+
+When working from `.beads` issues, coordinate for parallel agents:
+
+1. **First step: sync and check current ownership**
+   - Run `bd sync --import-only` if needed.
+   - Check whether the target issue is already `in_progress` before claiming it.
+2. **Do not claim issues already in progress**
+   - If an issue is `in_progress`, pick another open issue instead of taking it.
+3. **Immediately claim when starting**
+   - As the first action on a new task, set `in_progress`:
+   - `bd update <issue-id> --status in_progress`
+4. **Only one active claim per agent**
+   - Avoid claiming multiple issues at once unless explicitly requested.
+
 ## Project Overview
 
 CardinalSin is a high-cardinality time-series database built on object storage (S3/GCS/Azure) that solves the cardinality explosion problem through columnar storage instead of per-tag-combination indexing.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -10,7 +10,7 @@
 pub mod ingest;
 pub mod query;
 
-use axum::Router;
+use axum::{extract::State, http::StatusCode, Router};
 use std::sync::Arc;
 
 /// Combined API server configuration
@@ -94,7 +94,10 @@ async fn health_check() -> &'static str {
 }
 
 /// Readiness check endpoint
-async fn ready_check() -> &'static str {
-    // In production, check dependencies
-    "READY"
+async fn ready_check(State(state): State<ApiState>) -> (StatusCode, &'static str) {
+    if state.ingester.wal_ready() {
+        (StatusCode::OK, "READY")
+    } else {
+        (StatusCode::SERVICE_UNAVAILABLE, "WAL_NOT_READY")
+    }
 }

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -247,6 +247,26 @@ impl Ingester {
         Ok(())
     }
 
+    /// Whether WAL durability is enabled by configuration.
+    pub fn wal_enabled(&self) -> bool {
+        self.config.wal.enabled
+    }
+
+    /// Whether WAL has been initialized and is actively protecting writes.
+    pub fn wal_initialized(&self) -> bool {
+        self.wal.is_some()
+    }
+
+    /// Whether the ingester is durability-ready.
+    pub fn wal_ready(&self) -> bool {
+        !self.wal_enabled() || self.wal_initialized()
+    }
+
+    /// WAL directory path from configuration.
+    pub fn wal_dir(&self) -> &std::path::Path {
+        &self.config.wal.wal_dir
+    }
+
     /// Write metrics to the buffer
     pub async fn write(&self, batch: RecordBatch) -> Result<()> {
         let start_time = std::time::Instant::now();

--- a/tests/wal_integration_tests.rs
+++ b/tests/wal_integration_tests.rs
@@ -151,6 +151,35 @@ async fn test_ensure_wal_initializes_and_recovers_empty() {
 }
 
 #[tokio::test]
+async fn test_wal_ready_transitions_after_initialization() {
+    let dir = TempDir::new().unwrap();
+    let config = make_ingester_config(make_wal_config(&dir));
+    let mut ingester = make_ingester(config);
+
+    assert!(ingester.wal_enabled());
+    assert!(!ingester.wal_initialized());
+    assert!(!ingester.wal_ready());
+
+    ingester.ensure_wal().await.unwrap();
+
+    assert!(ingester.wal_initialized());
+    assert!(ingester.wal_ready());
+}
+
+#[test]
+fn test_wal_ready_when_disabled() {
+    let dir = TempDir::new().unwrap();
+    let mut wal_config = make_wal_config(&dir);
+    wal_config.enabled = false;
+    let config = make_ingester_config(wal_config);
+    let ingester = make_ingester(config);
+
+    assert!(!ingester.wal_enabled());
+    assert!(!ingester.wal_initialized());
+    assert!(ingester.wal_ready());
+}
+
+#[tokio::test]
 async fn test_wal_recovery_replays_unflushed_entries() {
     let dir = TempDir::new().unwrap();
     let wal_config = make_wal_config(&dir);


### PR DESCRIPTION
## Summary
- initialize WAL during ingester and query-node startup before serving traffic
- fail fast on WAL init errors by default, with explicit opt-out via WAL_ALLOW_STARTUP_WITHOUT_DURABILITY
- expose WAL readiness via /ready (returns 503 WAL_NOT_READY when durability is not active)
- add WAL readiness helper methods and integration tests
- document beads claiming protocol in CLAUDE.md (check in_progress before claim, claim immediately)

## Validation
- cargo test --test wal_integration_tests --quiet
- cargo check --bins --quiet

Closes #22