### PR TITLE
Refine Docker publish workflow gating and tag discovery

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,66 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'deploy/Dockerfile'
+  workflow_dispatch:
+    inputs:
+      publish_enabled:
+        description: 'Set to true to allow this manual run to publish'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main' && vars.DOCKER_PUBLISH_ENABLED == 'true') ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' && inputs.publish_enabled == 'true' && vars.DOCKER_PUBLISH_ENABLED == 'true')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
### Motivation
- Prevent accidental or unauthorized image publishes by tightening the gating for both automatic and manual runs. 
- Ensure `docker/metadata-action` can discover semver tags reliably so published image tags reflect repository versions.

### Description
- Restrict manual dispatch so `workflow_dispatch` runs only on the `main` branch and still requires `publish_enabled == 'true'` and `vars.DOCKER_PUBLISH_ENABLED == 'true'`. 
- Update the checkout step to include `fetch-depth: 0` so tag history is available for `type=semver,pattern={{version}}` metadata. 
- Document runtime prerequisites: set `DOCKER_PUBLISH_ENABLED=true` as a repo/org variable, use `secrets.GITHUB_TOKEN` for GHCR login, and the workflow requires `contents: read` and `packages: write` permissions; manual runs must set `publish_enabled=true` in the dispatch form. 

### Testing
- Ran `git diff --check` to validate the patch format and it succeeded. 
- Printed and inspected the workflow with `nl -ba .github/workflows/docker-publish.yml | sed -n '1,220p'` and `git diff -- .github/workflows/docker-publish.yml` to verify the changes and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994900d67c483259f017b6422aba2a0)