### PR TITLE
Add GitHub Actions CI workflow for Rust (fmt, clippy, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: ci-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --workspace --all-targets --all-features


### PR DESCRIPTION
### Motivation
- Add automated CI to enforce formatting, linting, and run tests for the Rust project on pull requests and manual dispatch while reducing duplicate runs and avoiding wasted runs for draft PRs.

### Description
- Create `.github/workflows/ci.yml` that triggers on `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_review`) and `workflow_dispatch`, configures `concurrency` as `ci-${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true`, and defines a single `test` job on `ubuntu-latest` that uses `actions/checkout@v4`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2` keyed on `Cargo.lock`, then runs `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --workspace --all-targets --all-features`, with a guard to skip draft PRs.

### Testing
- Validated the new workflow file contents with `sed -n '1,200p' .github/workflows/ci.yml` and `nl -ba .github/workflows/ci.yml`, and both inspections completed successfully; no CI runs were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994900168248325b4080297daa26f32)