### PR TITLE
Remove nightly-only rustfmt features for stable CI compatibility

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,5 +5,3 @@ tab_spaces = 4
 newline_style = "Unix"
 use_field_init_shorthand = true
 use_try_shorthand = true
-imports_granularity = "Crate"
-group_imports = "StdExternalCrate"


### PR DESCRIPTION
## Summary
- Remove `imports_granularity = "Crate"` and `group_imports = "StdExternalCrate"` from `rustfmt.toml`
- These features require nightly rustfmt but CI uses stable Rust toolchain
- Eliminates formatting check false-failures across all PR branches

## Context
All 14 open PRs (#4-18) are failing CI due to this mismatch. Once merged, those PRs can be re-rebased to pick up the fix.

## Test plan
- [x] `cargo fmt --all -- --check` passes locally with stable rustfmt
- [x] No code formatting changes needed (code already matches stable rules)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>