### PR TITLE
feat(telemetry): SQL and PromQL query pack for diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ cargo build --release
 cargo test
 ```
 
+### Telemetry Query Pack
+
+```bash
+scripts/telemetry/run_query_pack.sh --mode all --run-id "run-20260222T190000Z"
+```
+
+Guide: `docs/telemetry/query-pack.md`
+
 ---
 
 ## API Interfaces

--- a/docs/telemetry/query-pack.md
+++ b/docs/telemetry/query-pack.md
@@ -1,0 +1,31 @@
+# Telemetry Query Pack
+
+Run live diagnostics:
+
+```bash
+scripts/telemetry/run_query_pack.sh --mode live --run-id "run-20260222T190000Z"
+```
+
+Run post-run forensics:
+
+```bash
+scripts/telemetry/run_query_pack.sh --mode postrun --run-id "run-20260222T190000Z"
+```
+
+Run both packs:
+
+```bash
+scripts/telemetry/run_query_pack.sh --mode all --run-id "run-20260222T190000Z"
+```
+
+Query definitions live in:
+
+- `scripts/telemetry/query-pack/live.promql`
+- `scripts/telemetry/query-pack/postrun.promql`
+- `scripts/telemetry/query-pack/live.sql`
+- `scripts/telemetry/query-pack/postrun.sql`
+
+Output artifacts are written to:
+
+- `benchmarks/results/query-pack-<timestamp>/promql/*.json`
+- `benchmarks/results/query-pack-<timestamp>/sql/*.json`

--- a/scripts/telemetry/query-pack/live.promql
+++ b/scripts/telemetry/query-pack/live.promql
@@ -1,0 +1,7 @@
+ingest_throughput_rps|sum(rate(cardinalsin_ingester_write_rows_total{run_id=~"__RUN_ID__"}[5m]))
+ingest_error_rps|sum(rate(cardinalsin_ingester_wal_operations_total{result="error",run_id=~"__RUN_ID__"}[5m]))
+query_latency_p99_seconds|histogram_quantile(0.99, sum(rate(cardinalsin_query_latency_seconds_bucket{run_id=~"__RUN_ID__"}[5m])) by (le))
+query_error_rps|sum(rate(cardinalsin_query_requests_total{result="error",run_id=~"__RUN_ID__"}[5m]))
+compaction_backlog_l0|max(cardinalsin_compaction_l0_pending_files{run_id=~"__RUN_ID__"})
+metadata_cas_conflict_rps|sum(rate(cardinalsin_metadata_cas_attempts_total{result="conflict",run_id=~"__RUN_ID__"}[5m]))
+cache_hit_ratio|sum(rate(cardinalsin_query_cache_hits_total{run_id=~"__RUN_ID__"}[5m])) / clamp_min(sum(rate(cardinalsin_query_cache_hits_total{run_id=~"__RUN_ID__"}[5m])) + sum(rate(cardinalsin_query_cache_misses_total{run_id=~"__RUN_ID__"}[5m])), 1)

--- a/scripts/telemetry/query-pack/live.sql
+++ b/scripts/telemetry/query-pack/live.sql
@@ -1,0 +1,3 @@
+metric_recent_avg|SELECT metric_name, avg(value) AS avg_value FROM metrics WHERE timestamp > now() - interval '5 minutes' GROUP BY metric_name ORDER BY avg_value DESC LIMIT 25
+metric_recent_p95|SELECT metric_name, percentile_cont(0.95) WITHIN GROUP (ORDER BY value) AS p95_value FROM metrics WHERE timestamp > now() - interval '5 minutes' GROUP BY metric_name ORDER BY p95_value DESC LIMIT 25
+recent_error_like_signals|SELECT timestamp, metric_name, value FROM metrics WHERE timestamp > now() - interval '5 minutes' AND metric_name LIKE '%error%' ORDER BY timestamp DESC LIMIT 200

--- a/scripts/telemetry/query-pack/postrun.promql
+++ b/scripts/telemetry/query-pack/postrun.promql
@@ -1,0 +1,6 @@
+ingest_rows_total|sum(increase(cardinalsin_ingester_write_rows_total{run_id=~"__RUN_ID__"}[24h]))
+query_errors_total|sum(increase(cardinalsin_query_requests_total{result="error",run_id=~"__RUN_ID__"}[24h]))
+compaction_jobs_total_by_result|sum by (result) (increase(cardinalsin_compaction_jobs_total{run_id=~"__RUN_ID__"}[24h]))
+metadata_cas_attempts_by_result|sum by (result) (increase(cardinalsin_metadata_cas_attempts_total{run_id=~"__RUN_ID__"}[24h]))
+max_l0_pending_24h|max_over_time(cardinalsin_compaction_l0_pending_files{run_id=~"__RUN_ID__"}[24h])
+split_actions_by_result|sum by (result) (increase(cardinalsin_split_actions_total{run_id=~"__RUN_ID__"}[24h]))

--- a/scripts/telemetry/query-pack/postrun.sql
+++ b/scripts/telemetry/query-pack/postrun.sql
@@ -1,0 +1,3 @@
+minute_rollup|SELECT date_trunc('minute', timestamp) AS minute, metric_name, avg(value) AS avg_value FROM metrics WHERE timestamp > now() - interval '60 minutes' GROUP BY minute, metric_name ORDER BY minute DESC LIMIT 1000
+peak_values|SELECT metric_name, max(value) AS max_value FROM metrics WHERE timestamp > now() - interval '24 hours' GROUP BY metric_name ORDER BY max_value DESC LIMIT 50
+signal_presence|SELECT metric_name, count(*) AS samples FROM metrics WHERE timestamp > now() - interval '24 hours' GROUP BY metric_name ORDER BY samples DESC LIMIT 100

--- a/scripts/telemetry/run_query_pack.sh
+++ b/scripts/telemetry/run_query_pack.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PACK_DIR="$ROOT_DIR/scripts/telemetry/query-pack"
+QUERY_ENDPOINT="${QUERY_ENDPOINT:-http://localhost:8080}"
+RUN_ID="${CARDINALSIN_TELEMETRY_RUN_ID:-.*}"
+MODE="${MODE:-live}"
+OUT_DIR="${OUT_DIR:-$ROOT_DIR/benchmarks/results/query-pack-$(date -u +%Y%m%dT%H%M%SZ)}"
+
+usage() {
+  cat <<EOF
+Usage: scripts/telemetry/run_query_pack.sh [--mode live|postrun|all] [--run-id run-...] [--out-dir path]
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$OUT_DIR/promql" "$OUT_DIR/sql"
+
+echo "query-pack mode=$MODE run_id=$RUN_ID"
+echo "out_dir=$OUT_DIR"
+
+run_prom_file() {
+  local file="$1"
+  while IFS='|' read -r name expr; do
+    [[ -z "${name:-}" ]] && continue
+    local rendered
+    rendered="${expr//__RUN_ID__/$RUN_ID}"
+    curl -fsS --get "$QUERY_ENDPOINT/api/v1/query" \
+      --data-urlencode "query=$rendered" \
+      > "$OUT_DIR/promql/$name.json" || true
+  done < "$file"
+}
+
+run_sql_file() {
+  local file="$1"
+  while IFS='|' read -r name query; do
+    [[ -z "${name:-}" ]] && continue
+    jq -n --arg q "$query" '{query: $q, format: "json"}' \
+      | curl -fsS -X POST "$QUERY_ENDPOINT/api/v1/sql" \
+          -H 'Content-Type: application/json' \
+          -d @- \
+      > "$OUT_DIR/sql/$name.json" || true
+  done < "$file"
+}
+
+case "$MODE" in
+  live)
+    run_prom_file "$PACK_DIR/live.promql"
+    run_sql_file "$PACK_DIR/live.sql"
+    ;;
+  postrun)
+    run_prom_file "$PACK_DIR/postrun.promql"
+    run_sql_file "$PACK_DIR/postrun.sql"
+    ;;
+  all)
+    run_prom_file "$PACK_DIR/live.promql"
+    run_prom_file "$PACK_DIR/postrun.promql"
+    run_sql_file "$PACK_DIR/live.sql"
+    run_sql_file "$PACK_DIR/postrun.sql"
+    ;;
+  *)
+    echo "Invalid mode: $MODE" >&2
+    exit 1
+    ;;
+esac
+
+echo "Wrote query pack outputs to $OUT_DIR"


### PR DESCRIPTION
Implements Epic #65 sub-item #75 (`cardinalsin-c5e.10`).

## Summary
- add telemetry query pack definitions for live and post-run diagnostics
- add executable query-pack runner for PromQL + SQL probes
- persist query-pack outputs as JSON artifacts
- document usage and add README entry

## Validation
- `bash -n scripts/telemetry/run_query_pack.sh`

Closes #75
Refs: #65