### PR TITLE
feat(grafana): provision datasource and dogfooding dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ This starts:
 - **Compactor** (background service)
 - **Grafana** on port 3000
 
+Grafana dashboards are provisioned automatically from:
+
+- `deploy/grafana/provisioning/datasources/cardinalsin.yaml`
+- `deploy/grafana/provisioning/dashboards/ingest-health.json`
+- `deploy/grafana/provisioning/dashboards/query-performance.json`
+- `deploy/grafana/provisioning/dashboards/compactor-metadata-health.json`
+- `deploy/grafana/provisioning/dashboards/run-overview.json`
+
 ### Building from Source
 
 ```bash

--- a/deploy/grafana/provisioning/dashboards/compactor-metadata-health.json
+++ b/deploy/grafana/provisioning/dashboards/compactor-metadata-health.json
@@ -1,0 +1,65 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "targets": [{"expr": "histogram_quantile(0.95, sum(rate(cardinalsin_compaction_cycle_duration_seconds_bucket{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) by (le))", "legendFormat": "p95", "refId": "A"}],
+      "title": "Compaction Cycle Duration p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "targets": [{"expr": "max(cardinalsin_compaction_l0_pending_files{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"})", "legendFormat": "pending L0", "refId": "A"}],
+      "title": "L0 Backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "targets": [{"expr": "sum(rate(cardinalsin_metadata_cas_attempts_total{result=\"conflict\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m]))", "legendFormat": "conflicts/sec", "refId": "A"}],
+      "title": "Metadata CAS Conflicts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "targets": [{"expr": "sum(rate(cardinalsin_metadata_lease_operations_total{result=\"error\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m]))", "legendFormat": "lease errors/sec", "refId": "A"}],
+      "title": "Lease Error Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["cardinalsin", "telemetry", "compactor", "metadata"],
+  "templating": {
+    "list": [
+      {"name": "run_id", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, run_id)", "includeAll": true, "allValue": ".*", "multi": false, "refresh": 1, "current": {"text": "All", "value": ".*"}},
+      {"name": "service", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, service)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}},
+      {"name": "tenant", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, tenant)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}}
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CardinalSin - Compactor and Metadata Health",
+  "uid": "cardinalsin-compactor-metadata",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/dashboards/dashboards.yaml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: CardinalSin Dashboards
+    orgId: 1
+    folder: CardinalSin
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/deploy/grafana/provisioning/dashboards/ingest-health.json
+++ b/deploy/grafana/provisioning/dashboards/ingest-health.json
@@ -1,0 +1,65 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "rows/s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "targets": [{"expr": "sum(rate(cardinalsin_ingester_write_rows_total{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[1m]))", "legendFormat": "rows/sec", "refId": "A"}],
+      "title": "Ingest Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "targets": [{"expr": "histogram_quantile(0.95, sum(rate(cardinalsin_ingester_write_latency_seconds_bucket{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) by (le))", "legendFormat": "p95", "refId": "A"}],
+      "title": "Write Latency p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "targets": [{"expr": "max(cardinalsin_ingester_buffer_fullness_ratio{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"})", "legendFormat": "buffer fullness", "refId": "A"}],
+      "title": "Buffer Fullness",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "targets": [{"expr": "sum(rate(cardinalsin_ingester_wal_operations_total{result=\"error\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m]))", "legendFormat": "wal errors/sec", "refId": "A"}],
+      "title": "WAL Error Rate",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["cardinalsin", "telemetry", "ingest"],
+  "templating": {
+    "list": [
+      {"name": "run_id", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, run_id)", "includeAll": true, "allValue": ".*", "multi": false, "refresh": 1, "current": {"text": "All", "value": ".*"}},
+      {"name": "service", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, service)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}},
+      {"name": "tenant", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, tenant)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}}
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CardinalSin - Ingest Health",
+  "uid": "cardinalsin-ingest-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/dashboards/query-performance.json
+++ b/deploy/grafana/provisioning/dashboards/query-performance.json
@@ -1,0 +1,65 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "targets": [{"expr": "histogram_quantile(0.99, sum(rate(cardinalsin_query_latency_seconds_bucket{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) by (le))", "legendFormat": "p99", "refId": "A"}],
+      "title": "Query Latency p99",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "targets": [{"expr": "sum(rate(cardinalsin_query_requests_total{result=\"error\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m]))", "legendFormat": "errors/sec", "refId": "A"}],
+      "title": "Query Error Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "percentunit", "min": 0, "max": 1}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "targets": [{"expr": "sum(rate(cardinalsin_query_cache_hits_total{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) / clamp_min(sum(rate(cardinalsin_query_cache_hits_total{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) + sum(rate(cardinalsin_query_cache_misses_total{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])), 1)", "legendFormat": "hit ratio", "refId": "A"}],
+      "title": "Cache Hit Ratio",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "Bps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "targets": [{"expr": "sum(rate(cardinalsin_query_bytes_scanned_total{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m]))", "legendFormat": "bytes scanned/sec", "refId": "A"}],
+      "title": "Scan Throughput",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["cardinalsin", "telemetry", "query"],
+  "templating": {
+    "list": [
+      {"name": "run_id", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, run_id)", "includeAll": true, "allValue": ".*", "multi": false, "refresh": 1, "current": {"text": "All", "value": ".*"}},
+      {"name": "service", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, service)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}},
+      {"name": "tenant", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, tenant)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}}
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CardinalSin - Query Performance",
+  "uid": "cardinalsin-query-performance",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/dashboards/run-overview.json
+++ b/deploy/grafana/provisioning/dashboards/run-overview.json
@@ -1,0 +1,65 @@
+{
+  "annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana", "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0, 211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]},
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "rows/s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0},
+      "id": 1,
+      "targets": [{"expr": "sum(rate(cardinalsin_ingester_write_rows_total{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[1m]))", "legendFormat": "ingest", "refId": "A"}],
+      "title": "Ingest Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
+      "id": 2,
+      "targets": [{"expr": "sum(rate(cardinalsin_query_requests_total{result=\"ok\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[1m]))", "legendFormat": "query", "refId": "A"}],
+      "title": "Query Throughput",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 8},
+      "id": 3,
+      "targets": [{"expr": "max(cardinalsin_compaction_l0_pending_files{run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"})", "legendFormat": "pending L0", "refId": "A"}],
+      "title": "Compaction Backlog",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"},
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 8},
+      "id": 4,
+      "targets": [{"expr": "sum(rate(cardinalsin_query_requests_total{result=\"error\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) + sum(rate(cardinalsin_ingester_wal_operations_total{result=\"error\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m])) + sum(rate(cardinalsin_metadata_cas_attempts_total{result=\"conflict\",run_id=~\"$run_id\",service=~\"$service\",tenant=~\"$tenant\"}[5m]))", "legendFormat": "error-like events/sec", "refId": "A"}],
+      "title": "Error Pressure",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["cardinalsin", "telemetry", "run"],
+  "templating": {
+    "list": [
+      {"name": "run_id", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, run_id)", "includeAll": true, "allValue": ".*", "multi": false, "refresh": 1, "current": {"text": "All", "value": ".*"}},
+      {"name": "service", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, service)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}},
+      {"name": "tenant", "type": "query", "datasource": {"type": "prometheus", "uid": "cardinalsin-prom"}, "query": "label_values(cardinalsin_compaction_cycle_duration_seconds, tenant)", "includeAll": true, "allValue": ".*", "multi": true, "refresh": 1, "current": {"text": "All", "value": [".*"]}}
+    ]
+  },
+  "time": {"from": "now-30m", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "CardinalSin - Benchmark Run Overview",
+  "uid": "cardinalsin-run-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/datasources/cardinalsin.yaml
+++ b/deploy/grafana/provisioning/datasources/cardinalsin.yaml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+datasources:
+  - name: CardinalSin
+    uid: cardinalsin-prom
+    type: prometheus
+    access: proxy
+    url: http://query:8080
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST
+      prometheusType: Prometheus
+      timeInterval: 10s


### PR DESCRIPTION
Implements Epic #65 sub-item #73 (`cardinalsin-c5e.8`).

## Summary
- add Grafana datasource provisioning for CardinalSin Prometheus-compatible API
- add dashboard provisioning provider
- add dashboard pack: ingest health, query performance, compactor/metadata health, run overview
- add README links for zero-manual setup

## Validation
- validate dashboard JSON files with `jq empty`

Closes #73
Refs: #65