### PR TITLE
Refactor storage config to provider/container model

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
 # Development configuration (default)
 # Uses in-memory storage for rapid iteration
 
-STORAGE_BACKEND=memory
+CLOUD_PROVIDER=memory
 METADATA_BACKEND=local
 
 # Logging

--- a/.env.production
+++ b/.env.production
@@ -1,12 +1,12 @@
 # Production configuration
 # Uses S3 for persistent, durable storage
 
-STORAGE_BACKEND=s3
-S3_BUCKET=cardinalsin-prod-data
+CLOUD_PROVIDER=aws
+STORAGE_CONTAINER=cardinalsin-prod-data
 S3_REGION=us-east-1
 
-METADATA_BACKEND=s3
-METADATA_BUCKET=cardinalsin-prod-metadata
+METADATA_BACKEND=object_store
+METADATA_CONTAINER=cardinalsin-prod-metadata
 METADATA_PREFIX=metadata/
 
 # AWS credentials (optional - will use IAM role if not set)

--- a/.env.staging
+++ b/.env.staging
@@ -1,8 +1,8 @@
 # Staging configuration
 # Uses MinIO for S3-compatible local testing
 
-STORAGE_BACKEND=s3
-S3_BUCKET=cardinalsin-staging
+CLOUD_PROVIDER=aws
+STORAGE_CONTAINER=cardinalsin-staging
 S3_ENDPOINT=http://localhost:9000
 S3_REGION=us-east-1
 
@@ -10,8 +10,8 @@ S3_REGION=us-east-1
 AWS_ACCESS_KEY_ID=minioadmin
 AWS_SECRET_ACCESS_KEY=minioadmin
 
-METADATA_BACKEND=s3
-METADATA_BUCKET=cardinalsin-staging
+METADATA_BACKEND=object_store
+METADATA_CONTAINER=cardinalsin-staging
 METADATA_PREFIX=metadata/
 
 # Logging

--- a/README.md
+++ b/README.md
@@ -396,9 +396,12 @@ CardinalSin supports real-time streaming for live dashboards and alerting by mer
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `S3_BUCKET` | `cardinalsin-data` | S3 bucket name |
-| `S3_REGION` | `us-east-1` | S3 region |
-| `S3_ENDPOINT` | — | S3 endpoint (for MinIO or other S3-compatible storage) |
+| `CLOUD_PROVIDER` | `memory` | Storage provider: `memory`, `aws`, `gcp`, `azure` |
+| `STORAGE_CONTAINER` | — | Container/bucket name for selected provider |
+| `METADATA_BACKEND` | `local` | `local` or `object_store` |
+| `METADATA_CONTAINER` | `STORAGE_CONTAINER` | Metadata container/bucket when using `object_store` backend |
+| `S3_REGION` | `us-east-1` | AWS region (AWS provider) |
+| `S3_ENDPOINT` | — | AWS S3 endpoint (for MinIO or other S3-compatible storage) |
 | `TENANT_ID` | `default` | Tenant identifier |
 | `RUST_LOG` | `info` | Log level (`trace`, `debug`, `info`, `warn`, `error`) |
 
@@ -409,7 +412,8 @@ cardinalsin-ingester \
   --http-port 8080 \
   --grpc-port 4317 \
   --flush-interval-secs 300 \
-  --bucket my-metrics
+  --cloud-provider aws \
+  --storage-container my-metrics
 ```
 
 ### Query Node Options

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -41,9 +41,9 @@ services:
     container_name: cardinalsin-ingester
     command: ["cardinalsin-ingester"]
     environment:
-      STORAGE_BACKEND: s3
+      CLOUD_PROVIDER: aws
       METADATA_BACKEND: s3
-      S3_BUCKET: cardinalsin-data
+      STORAGE_CONTAINER: cardinalsin-data
       S3_REGION: us-east-1
       S3_ENDPOINT: http://minio:9000
       S3_METADATA_ALLOW_UNSAFE_OVERWRITE: "true"
@@ -75,9 +75,9 @@ services:
     container_name: cardinalsin-query
     command: ["cardinalsin-query"]
     environment:
-      STORAGE_BACKEND: s3
+      CLOUD_PROVIDER: aws
       METADATA_BACKEND: s3
-      S3_BUCKET: cardinalsin-data
+      STORAGE_CONTAINER: cardinalsin-data
       S3_REGION: us-east-1
       S3_ENDPOINT: http://minio:9000
       S3_METADATA_ALLOW_UNSAFE_OVERWRITE: "true"
@@ -108,9 +108,9 @@ services:
     container_name: cardinalsin-compactor
     command: ["cardinalsin-compactor"]
     environment:
-      STORAGE_BACKEND: s3
+      CLOUD_PROVIDER: aws
       METADATA_BACKEND: s3
-      S3_BUCKET: cardinalsin-data
+      STORAGE_CONTAINER: cardinalsin-data
       S3_REGION: us-east-1
       S3_ENDPOINT: http://minio:9000
       S3_METADATA_ALLOW_UNSAFE_OVERWRITE: "true"

--- a/src/bin/backfill_levels.rs
+++ b/src/bin/backfill_levels.rs
@@ -2,35 +2,32 @@
 //!
 //! This tool scans existing chunk metadata and assigns appropriate levels
 //! based on chunk paths and naming patterns.
-//!
-//! Usage:
-//!   cargo run --bin backfill-levels -- --bucket cardinalsin-metadata --prefix metadata/
 
-use cardinalsin::metadata::{S3MetadataClient, S3MetadataConfig};
+use cardinalsin::config::ComponentFactory;
+use cardinalsin::metadata::{ObjectStoreMetadataClient, ObjectStoreMetadataConfig};
 use cardinalsin::telemetry::Telemetry;
+use cardinalsin::StorageConfig;
 use clap::Parser;
-use object_store::aws::AmazonS3Builder;
-use std::sync::Arc;
 use tracing::info;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// S3 bucket name
-    #[arg(short, long, default_value = "cardinalsin-metadata")]
-    bucket: String,
+    /// Cloud provider (memory, aws, gcp, azure)
+    #[arg(long, env = "CLOUD_PROVIDER")]
+    cloud_provider: Option<String>,
 
-    /// Metadata prefix in S3
+    /// Metadata container/bucket
+    #[arg(short, long, env = "METADATA_CONTAINER")]
+    container: Option<String>,
+
+    /// Deprecated alias for --container
+    #[arg(long, env = "METADATA_BUCKET", hide = true)]
+    bucket: Option<String>,
+
+    /// Metadata prefix
     #[arg(short, long, default_value = "metadata/")]
     prefix: String,
-
-    /// S3 region
-    #[arg(short, long, default_value = "us-east-1")]
-    region: String,
-
-    /// S3 endpoint (for MinIO or other S3-compatible storage)
-    #[arg(short, long)]
-    endpoint: Option<String>,
 
     /// Dry run - don't actually update metadata
     #[arg(long, default_value = "false")]
@@ -42,27 +39,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _telemetry = Telemetry::init_for_component("cardinalsin-backfill-levels", "info")?;
 
     let args = Args::parse();
+    let metadata_storage = ComponentFactory::resolve_storage_config(
+        args.cloud_provider.as_deref(),
+        args.container.as_deref().or(args.bucket.as_deref()),
+        "metadata",
+    )?;
 
     info!("Starting level backfill migration");
-    info!("  Bucket: {}", args.bucket);
+    info!("  Provider: {}", metadata_storage.provider.as_str());
+    info!("  Container: {}", metadata_storage.container);
     info!("  Prefix: {}", args.prefix);
-    info!("  Region: {}", args.region);
     info!("  Dry run: {}", args.dry_run);
 
-    // Create S3 client
-    let mut builder = AmazonS3Builder::new()
-        .with_bucket_name(&args.bucket)
-        .with_region(&args.region);
+    let metadata_store = StorageConfig {
+        provider: metadata_storage.provider,
+        container: metadata_storage.container.clone(),
+        tenant_id: metadata_storage.tenant_id.clone(),
+    };
+    let object_store = ComponentFactory::create_object_store_for(&metadata_store).await?;
 
-    if let Some(endpoint) = &args.endpoint {
-        builder = builder.with_endpoint(endpoint);
-    }
-
-    let object_store = Arc::new(builder.build()?);
-
-    // Create metadata client
-    let config = S3MetadataConfig {
-        bucket: args.bucket.clone(),
+    let config = ObjectStoreMetadataConfig {
+        bucket: metadata_storage.container,
         metadata_prefix: args.prefix.clone(),
         enable_cache: false,
         allow_unsafe_overwrite: std::env::var("S3_METADATA_ALLOW_UNSAFE_OVERWRITE")
@@ -73,18 +70,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .unwrap_or(false),
     };
 
-    let metadata_client = S3MetadataClient::new(object_store, config);
+    let metadata_client = ObjectStoreMetadataClient::new(object_store, config);
 
-    // Rebuild time index (also loads all chunks)
     info!("Rebuilding time index from chunk metadata...");
     metadata_client.rebuild_time_index().await?;
 
     info!("Level backfill migration complete!");
     info!("Note: Actual level assignment happens automatically during compaction.");
-    info!("Existing chunks will default to level=0 (L0) and be promoted during next compaction cycle.");
+    info!("Existing chunks default to level=0 (L0) and are promoted during compaction.");
 
     if args.dry_run {
-        info!("DRY RUN - No changes were made");
+        info!("DRY RUN - no changes were made");
     }
 
     Ok(())

--- a/src/bin/ingester.rs
+++ b/src/bin/ingester.rs
@@ -8,7 +8,7 @@ use cardinalsin::ingester::{Ingester, IngesterConfig, WalConfig, WalSyncMode};
 use cardinalsin::query::{QueryConfig, QueryNode};
 use cardinalsin::schema::MetricSchema;
 use cardinalsin::telemetry::Telemetry;
-use cardinalsin::{Error, StorageConfig};
+use cardinalsin::Error;
 
 use clap::Parser;
 use std::net::SocketAddr;
@@ -30,17 +30,17 @@ struct Args {
     #[arg(long, default_value = "4317")]
     grpc_port: u16,
 
-    /// S3 bucket name
-    #[arg(long, env = "S3_BUCKET", default_value = "cardinalsin-data")]
-    bucket: String,
+    /// Cloud provider (memory, aws, gcp, azure)
+    #[arg(long, env = "CLOUD_PROVIDER")]
+    cloud_provider: Option<String>,
 
-    /// S3 region
-    #[arg(long, env = "S3_REGION", default_value = "us-east-1")]
-    region: String,
+    /// Provider container/bucket
+    #[arg(long, env = "STORAGE_CONTAINER")]
+    storage_container: Option<String>,
 
-    /// S3 endpoint (for MinIO)
-    #[arg(long, env = "S3_ENDPOINT")]
-    endpoint: Option<String>,
+    /// Deprecated alias for --storage-container
+    #[arg(long, env = "S3_BUCKET", hide = true)]
+    bucket: Option<String>,
 
     /// Tenant ID
     #[arg(long, env = "TENANT_ID", default_value = "default")]
@@ -79,19 +79,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting CardinalSin Ingester");
 
-    // Create storage config
-    let storage_config = StorageConfig {
-        bucket: args.bucket.clone(),
-        region: args.region.clone(),
-        endpoint: args.endpoint.clone(),
-        tenant_id: args.tenant_id.clone(),
-    };
+    let storage_config = ComponentFactory::resolve_storage_config(
+        args.cloud_provider.as_deref(),
+        args.storage_container.as_deref().or(args.bucket.as_deref()),
+        args.tenant_id.clone(),
+    )?;
 
-    // Create object store from environment
-    let object_store = ComponentFactory::create_object_store().await?;
+    let object_store = ComponentFactory::create_object_store_for(&storage_config).await?;
 
     // Create metadata client from environment
-    let metadata = ComponentFactory::create_metadata_client(object_store.clone()).await?;
+    let metadata =
+        ComponentFactory::create_metadata_client_for_storage(object_store.clone(), &storage_config)
+            .await?;
 
     // Parse WAL sync mode
     let wal_sync_mode: WalSyncMode = args
@@ -144,9 +143,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let query_node = Arc::new(
         QueryNode::new(
             QueryConfig::default(),
-            ComponentFactory::create_object_store().await?,
-            ComponentFactory::create_metadata_client(
-                ComponentFactory::create_object_store().await?,
+            ComponentFactory::create_object_store_for(&storage_config).await?,
+            ComponentFactory::create_metadata_client_for_storage(
+                ComponentFactory::create_object_store_for(&storage_config).await?,
+                &storage_config,
             )
             .await?,
             storage_config.clone(),

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -8,7 +8,7 @@ use cardinalsin::ingester::{Ingester, IngesterConfig};
 use cardinalsin::query::{QueryConfig, QueryNode};
 use cardinalsin::schema::MetricSchema;
 use cardinalsin::telemetry::Telemetry;
-use cardinalsin::{Error, StorageConfig};
+use cardinalsin::Error;
 
 use clap::Parser;
 use std::net::SocketAddr;
@@ -30,17 +30,17 @@ struct Args {
     #[arg(long, default_value = "8815")]
     grpc_port: u16,
 
-    /// S3 bucket name
-    #[arg(long, env = "S3_BUCKET", default_value = "cardinalsin-data")]
-    bucket: String,
+    /// Cloud provider (memory, aws, gcp, azure)
+    #[arg(long, env = "CLOUD_PROVIDER")]
+    cloud_provider: Option<String>,
 
-    /// S3 region
-    #[arg(long, env = "S3_REGION", default_value = "us-east-1")]
-    region: String,
+    /// Provider container/bucket
+    #[arg(long, env = "STORAGE_CONTAINER")]
+    storage_container: Option<String>,
 
-    /// S3 endpoint (for MinIO)
-    #[arg(long, env = "S3_ENDPOINT")]
-    endpoint: Option<String>,
+    /// Deprecated alias for --storage-container
+    #[arg(long, env = "S3_BUCKET", hide = true)]
+    bucket: Option<String>,
 
     /// Tenant ID
     #[arg(long, env = "TENANT_ID", default_value = "default")]
@@ -71,19 +71,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting CardinalSin Query Node");
 
-    // Create storage config
-    let storage_config = StorageConfig {
-        bucket: args.bucket.clone(),
-        region: args.region.clone(),
-        endpoint: args.endpoint.clone(),
-        tenant_id: args.tenant_id.clone(),
-    };
+    let storage_config = ComponentFactory::resolve_storage_config(
+        args.cloud_provider.as_deref(),
+        args.storage_container.as_deref().or(args.bucket.as_deref()),
+        args.tenant_id.clone(),
+    )?;
 
-    // Create object store from environment
-    let object_store = ComponentFactory::create_object_store().await?;
+    let object_store = ComponentFactory::create_object_store_for(&storage_config).await?;
 
     // Create metadata client from environment
-    let metadata = ComponentFactory::create_metadata_client(object_store.clone()).await?;
+    let metadata =
+        ComponentFactory::create_metadata_client_for_storage(object_store.clone(), &storage_config)
+            .await?;
 
     // Create query config
     let query_config = QueryConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,80 +4,123 @@
 //! based on environment variables, enabling easy switching between development and
 //! production configurations.
 
-use crate::metadata::{LocalMetadataClient, MetadataClient, S3MetadataClient, S3MetadataConfig};
-use crate::Result;
-use object_store::{aws::AmazonS3Builder, memory::InMemory, ObjectStore};
+use crate::metadata::{
+    LocalMetadataClient, MetadataClient, ObjectStoreMetadataClient, ObjectStoreMetadataConfig,
+};
+use crate::{CloudProvider, Result, StorageConfig};
+use object_store::{
+    aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
+    memory::InMemory, ObjectStore,
+};
 use std::sync::Arc;
-use tracing::info;
+use tracing::{info, warn};
 
 pub struct ComponentFactory;
 
 impl ComponentFactory {
-    /// Create object store from environment
+    /// Resolve a provider-neutral storage config from overrides and environment.
+    pub fn resolve_storage_config(
+        provider_override: Option<&str>,
+        container_override: Option<&str>,
+        tenant_id: impl Into<String>,
+    ) -> Result<StorageConfig> {
+        let provider = Self::resolve_cloud_provider(provider_override)?;
+        let container = Self::resolve_storage_container(provider, container_override)?;
+
+        Ok(StorageConfig {
+            provider,
+            container,
+            tenant_id: tenant_id.into(),
+        })
+    }
+
+    /// Create object store from environment.
     ///
     /// Environment variables:
-    /// - STORAGE_BACKEND: "memory" (default) or "s3"
-    /// - S3_BUCKET: S3 bucket name (required for s3)
-    /// - S3_REGION: S3 region (default: us-east-1)
-    /// - S3_ENDPOINT: Custom S3 endpoint (optional, for MinIO)
-    /// - AWS_ACCESS_KEY_ID: AWS credentials (optional, uses IAM role if not set)
-    /// - AWS_SECRET_ACCESS_KEY: AWS credentials (optional)
+    /// - CLOUD_PROVIDER: "memory" (default), "aws", "gcp", or "azure"
+    /// - STORAGE_CONTAINER: provider container/bucket name (required for aws/gcp/azure)
+    /// - STORAGE_BACKEND: deprecated alias for CLOUD_PROVIDER
     pub async fn create_object_store() -> Result<Arc<dyn ObjectStore>> {
-        let backend = std::env::var("STORAGE_BACKEND").unwrap_or_else(|_| "memory".to_string());
+        let storage = Self::resolve_storage_config(None, None, "default")?;
+        Self::create_object_store_for(&storage).await
+    }
 
-        match backend.as_str() {
-            "memory" => {
+    /// Create object store from explicit storage configuration.
+    pub async fn create_object_store_for(storage: &StorageConfig) -> Result<Arc<dyn ObjectStore>> {
+        Self::warn_ignored_provider_envs(storage.provider);
+
+        match storage.provider {
+            CloudProvider::Memory => {
                 info!("Using in-memory object store (development mode)");
                 Ok(Arc::new(InMemory::new()))
             }
-            "s3" => {
-                let bucket = std::env::var("S3_BUCKET").map_err(|_| {
-                    crate::Error::Config("S3_BUCKET required when STORAGE_BACKEND=s3".to_string())
-                })?;
-                let region = std::env::var("S3_REGION").unwrap_or_else(|_| "us-east-1".to_string());
+            CloudProvider::Aws => {
+                let region = Self::read_env("S3_REGION").unwrap_or_else(|| "us-east-1".to_string());
 
                 info!(
-                    "Using S3 object store: bucket={}, region={}",
-                    bucket, region
+                    provider = "aws",
+                    container = %storage.container,
+                    region = %region,
+                    "Using object store"
                 );
 
                 let mut builder = AmazonS3Builder::new()
-                    .with_bucket_name(&bucket)
+                    .with_bucket_name(&storage.container)
                     .with_region(&region);
 
-                // Support custom endpoints (MinIO, LocalStack)
-                if let Ok(endpoint) = std::env::var("S3_ENDPOINT") {
-                    info!("Using custom S3 endpoint: {}", endpoint);
+                if let Some(endpoint) = Self::read_env("S3_ENDPOINT") {
+                    info!(endpoint = %endpoint, "Using custom S3 endpoint");
                     builder = builder.with_endpoint(&endpoint).with_allow_http(true);
                 }
 
-                // Use explicit credentials if provided, otherwise use IAM role
-                if let Ok(key) = std::env::var("AWS_ACCESS_KEY_ID") {
+                if let Some(key) = Self::read_env("AWS_ACCESS_KEY_ID") {
                     builder = builder.with_access_key_id(&key);
                 }
-                if let Ok(secret) = std::env::var("AWS_SECRET_ACCESS_KEY") {
+                if let Some(secret) = Self::read_env("AWS_SECRET_ACCESS_KEY") {
                     builder = builder.with_secret_access_key(&secret);
                 }
 
                 Ok(Arc::new(builder.build()?))
             }
-            _ => Err(crate::Error::Config(format!(
-                "Unknown STORAGE_BACKEND: {}. Use 'memory' or 's3'",
-                backend
-            ))),
+            CloudProvider::Gcp => {
+                info!(provider = "gcp", container = %storage.container, "Using object store");
+                let store = GoogleCloudStorageBuilder::from_env()
+                    .with_bucket_name(&storage.container)
+                    .build()?;
+                Ok(Arc::new(store))
+            }
+            CloudProvider::Azure => {
+                info!(provider = "azure", container = %storage.container, "Using object store");
+                let store = MicrosoftAzureBuilder::from_env()
+                    .with_container_name(&storage.container)
+                    .build()?;
+                Ok(Arc::new(store))
+            }
         }
     }
 
-    /// Create metadata client from environment
+    /// Create metadata client from environment.
     ///
     /// Environment variables:
-    /// - METADATA_BACKEND: "local" (default) or "s3"
-    /// - METADATA_BUCKET: S3 bucket for metadata (defaults to S3_BUCKET)
-    /// - METADATA_PREFIX: S3 prefix for metadata (default: metadata/)
+    /// - METADATA_BACKEND: "local" (default) or "object_store"
+    /// - METADATA_BACKEND=s3: deprecated alias for "object_store"
+    /// - METADATA_CONTAINER: metadata container/bucket (optional, defaults to STORAGE_CONTAINER)
+    /// - METADATA_BUCKET: deprecated alias for METADATA_CONTAINER
+    /// - METADATA_PREFIX: object-store prefix for metadata (default: metadata/)
     pub async fn create_metadata_client(
         object_store: Arc<dyn ObjectStore>,
     ) -> Result<Arc<dyn MetadataClient>> {
-        let backend = std::env::var("METADATA_BACKEND").unwrap_or_else(|_| "local".to_string());
+        let storage = Self::resolve_storage_config(None, None, "default")?;
+        Self::create_metadata_client_for_storage(object_store, &storage).await
+    }
+
+    /// Create metadata client using an explicit storage configuration.
+    pub async fn create_metadata_client_for_storage(
+        object_store: Arc<dyn ObjectStore>,
+        storage: &StorageConfig,
+    ) -> Result<Arc<dyn MetadataClient>> {
+        let backend_raw = Self::read_env("METADATA_BACKEND").unwrap_or_else(|| "local".to_string());
+        let backend = backend_raw.trim().to_ascii_lowercase();
 
         match backend.as_str() {
             "local" => {
@@ -85,40 +128,622 @@ impl ComponentFactory {
                 Ok(Arc::new(LocalMetadataClient::new()))
             }
             "s3" => {
-                let bucket = std::env::var("METADATA_BUCKET")
-                    .or_else(|_| std::env::var("S3_BUCKET"))
-                    .map_err(|_| {
-                        crate::Error::Config(
-                            "METADATA_BUCKET or S3_BUCKET required when METADATA_BACKEND=s3"
-                                .to_string(),
-                        )
-                    })?;
-                let prefix =
-                    std::env::var("METADATA_PREFIX").unwrap_or_else(|_| "metadata/".to_string());
-
-                info!(
-                    "Using S3MetadataClient: bucket={}, prefix={}",
-                    bucket, prefix
-                );
-
-                let config = S3MetadataConfig {
-                    bucket,
-                    metadata_prefix: prefix,
-                    enable_cache: true,
-                    allow_unsafe_overwrite: std::env::var("S3_METADATA_ALLOW_UNSAFE_OVERWRITE")
-                        .map(|value| {
-                            let value = value.trim();
-                            value == "1" || value.eq_ignore_ascii_case("true")
-                        })
-                        .unwrap_or(false),
-                };
-
-                Ok(Arc::new(S3MetadataClient::new(object_store, config)))
+                warn!("METADATA_BACKEND=s3 is deprecated; use METADATA_BACKEND=object_store");
+                Self::create_object_store_metadata_client(object_store, storage).await
+            }
+            "object_store" => {
+                Self::create_object_store_metadata_client(object_store, storage).await
             }
             _ => Err(crate::Error::Config(format!(
-                "Unknown METADATA_BACKEND: {}. Use 'local' or 's3'",
-                backend
+                "Unknown METADATA_BACKEND: {}. Use 'local' or 'object_store'",
+                backend_raw
             ))),
         }
+    }
+
+    async fn create_object_store_metadata_client(
+        object_store: Arc<dyn ObjectStore>,
+        storage: &StorageConfig,
+    ) -> Result<Arc<dyn MetadataClient>> {
+        let provider = storage.provider;
+        let storage_container = storage.container.clone();
+
+        let metadata_container = match (
+            Self::read_env("METADATA_CONTAINER"),
+            Self::read_env("METADATA_BUCKET"),
+        ) {
+            (Some(container), Some(bucket)) => {
+                if container != bucket {
+                    warn!(
+                        metadata_container = %container,
+                        metadata_bucket = %bucket,
+                        "Ignoring METADATA_BUCKET because METADATA_CONTAINER is set"
+                    );
+                }
+                container
+            }
+            (Some(container), None) => container,
+            (None, Some(bucket)) => {
+                warn!("METADATA_BUCKET is deprecated; use METADATA_CONTAINER");
+                bucket
+            }
+            (None, None) => storage_container.clone(),
+        };
+
+        let metadata_store = if metadata_container == storage_container {
+            object_store
+        } else {
+            warn!(
+                storage_container = %storage_container,
+                metadata_container = %metadata_container,
+                "Creating dedicated object store for metadata container"
+            );
+            let metadata_storage = StorageConfig {
+                provider,
+                container: metadata_container.clone(),
+                tenant_id: "metadata".to_string(),
+            };
+            Self::create_object_store_for(&metadata_storage).await?
+        };
+
+        let prefix = Self::read_env("METADATA_PREFIX").unwrap_or_else(|| "metadata/".to_string());
+
+        info!(
+            backend = "object_store",
+            provider = %provider.as_str(),
+            container = %metadata_container,
+            prefix = %prefix,
+            "Using metadata client"
+        );
+
+        let config = ObjectStoreMetadataConfig {
+            bucket: metadata_container,
+            metadata_prefix: prefix,
+            enable_cache: true,
+            allow_unsafe_overwrite: Self::read_bool_env("S3_METADATA_ALLOW_UNSAFE_OVERWRITE"),
+        };
+
+        Ok(Arc::new(ObjectStoreMetadataClient::new(
+            metadata_store,
+            config,
+        )))
+    }
+
+    fn resolve_cloud_provider(provider_override: Option<&str>) -> Result<CloudProvider> {
+        if let Some(override_value) = provider_override.and_then(Self::normalize) {
+            return Self::parse_provider("cloud-provider override", &override_value);
+        }
+
+        let cloud_provider = Self::read_env("CLOUD_PROVIDER");
+        let storage_backend = Self::read_env("STORAGE_BACKEND");
+
+        match (cloud_provider, storage_backend) {
+            (Some(provider_raw), Some(backend_raw)) => {
+                let provider = Self::parse_provider("CLOUD_PROVIDER", &provider_raw)?;
+                let legacy = Self::parse_provider("STORAGE_BACKEND", &backend_raw)?;
+
+                if provider != legacy {
+                    warn!(
+                        cloud_provider = %provider_raw,
+                        storage_backend = %backend_raw,
+                        "Ignoring STORAGE_BACKEND because CLOUD_PROVIDER is set"
+                    );
+                } else {
+                    warn!("STORAGE_BACKEND is deprecated; remove it and keep CLOUD_PROVIDER only");
+                }
+
+                Ok(provider)
+            }
+            (Some(provider_raw), None) => Self::parse_provider("CLOUD_PROVIDER", &provider_raw),
+            (None, Some(backend_raw)) => {
+                warn!("STORAGE_BACKEND is deprecated; use CLOUD_PROVIDER");
+                Self::parse_provider("STORAGE_BACKEND", &backend_raw)
+            }
+            (None, None) => Ok(CloudProvider::Memory),
+        }
+    }
+
+    fn resolve_storage_container(
+        provider: CloudProvider,
+        container_override: Option<&str>,
+    ) -> Result<String> {
+        if let Some(container) = container_override.and_then(Self::normalize) {
+            return Ok(container);
+        }
+
+        let common = Self::read_env("STORAGE_CONTAINER");
+
+        match provider {
+            CloudProvider::Memory => Ok(common.unwrap_or_else(|| "cardinalsin-data".to_string())),
+            CloudProvider::Aws => {
+                let legacy = Self::read_env("S3_BUCKET");
+
+                match (common, legacy) {
+                    (Some(container), Some(bucket)) => {
+                        if container != bucket {
+                            warn!(
+                                storage_container = %container,
+                                s3_bucket = %bucket,
+                                "Ignoring S3 bucket because STORAGE_CONTAINER is set"
+                            );
+                        }
+                        Ok(container)
+                    }
+                    (Some(container), None) => Ok(container),
+                    (None, Some(bucket)) => {
+                        warn!("S3_BUCKET is deprecated for selection; prefer STORAGE_CONTAINER");
+                        Ok(bucket)
+                    }
+                    (None, None) => Err(crate::Error::Config(
+                        "STORAGE_CONTAINER or S3_BUCKET required when CLOUD_PROVIDER=aws"
+                            .to_string(),
+                    )),
+                }
+            }
+            CloudProvider::Gcp => {
+                let google_bucket = Self::read_env("GOOGLE_BUCKET")
+                    .or_else(|| Self::read_env("GOOGLE_BUCKET_NAME"));
+
+                match (common, google_bucket) {
+                    (Some(container), Some(bucket)) => {
+                        if container != bucket {
+                            warn!(
+                                storage_container = %container,
+                                google_bucket = %bucket,
+                                "Ignoring GOOGLE_BUCKET because STORAGE_CONTAINER is set"
+                            );
+                        }
+                        Ok(container)
+                    }
+                    (Some(container), None) => Ok(container),
+                    (None, Some(bucket)) => Ok(bucket),
+                    (None, None) => Err(crate::Error::Config(
+                        "STORAGE_CONTAINER, GOOGLE_BUCKET, or GOOGLE_BUCKET_NAME required when CLOUD_PROVIDER=gcp".to_string(),
+                    )),
+                }
+            }
+            CloudProvider::Azure => {
+                let azure_container = Self::read_env("AZURE_CONTAINER_NAME");
+
+                match (common, azure_container) {
+                    (Some(container), Some(azure_name)) => {
+                        if container != azure_name {
+                            warn!(
+                                storage_container = %container,
+                                azure_container_name = %azure_name,
+                                "Ignoring AZURE_CONTAINER_NAME because STORAGE_CONTAINER is set"
+                            );
+                        }
+                        Ok(container)
+                    }
+                    (Some(container), None) => Ok(container),
+                    (None, Some(azure_name)) => Ok(azure_name),
+                    (None, None) => Err(crate::Error::Config(
+                        "STORAGE_CONTAINER or AZURE_CONTAINER_NAME required when CLOUD_PROVIDER=azure".to_string(),
+                    )),
+                }
+            }
+        }
+    }
+
+    fn parse_provider(source: &str, value: &str) -> Result<CloudProvider> {
+        value
+            .parse::<CloudProvider>()
+            .map_err(|e| crate::Error::Config(format!("invalid {} '{}': {}", source, value, e)))
+    }
+
+    fn warn_ignored_provider_envs(selected_provider: CloudProvider) {
+        const AWS_KEYS: &[&str] = &[
+            "S3_BUCKET",
+            "S3_REGION",
+            "S3_ENDPOINT",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_SESSION_TOKEN",
+        ];
+        const GCP_KEYS: &[&str] = &[
+            "GOOGLE_BUCKET",
+            "GOOGLE_BUCKET_NAME",
+            "GOOGLE_SERVICE_ACCOUNT",
+            "GOOGLE_SERVICE_ACCOUNT_PATH",
+            "GOOGLE_SERVICE_ACCOUNT_KEY",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "SERVICE_ACCOUNT",
+            "SERVICE_ACCOUNT_PATH",
+            "SERVICE_ACCOUNT_KEY",
+        ];
+        const AZURE_KEYS: &[&str] = &[
+            "AZURE_CONTAINER_NAME",
+            "AZURE_STORAGE_ACCOUNT_NAME",
+            "AZURE_STORAGE_ACCOUNT_KEY",
+            "AZURE_STORAGE_ACCESS_KEY",
+            "AZURE_STORAGE_CLIENT_ID",
+            "AZURE_STORAGE_CLIENT_SECRET",
+            "AZURE_STORAGE_TENANT_ID",
+            "AZURE_STORAGE_ENDPOINT",
+            "AZURE_CLIENT_ID",
+            "AZURE_CLIENT_SECRET",
+            "AZURE_TENANT_ID",
+        ];
+
+        let mut ignored = Vec::new();
+
+        match selected_provider {
+            CloudProvider::Memory => {
+                ignored.extend(Self::collect_set_env_vars(AWS_KEYS));
+                ignored.extend(Self::collect_set_env_vars(GCP_KEYS));
+                ignored.extend(Self::collect_set_env_vars(AZURE_KEYS));
+            }
+            CloudProvider::Aws => {
+                ignored.extend(Self::collect_set_env_vars(GCP_KEYS));
+                ignored.extend(Self::collect_set_env_vars(AZURE_KEYS));
+            }
+            CloudProvider::Gcp => {
+                ignored.extend(Self::collect_set_env_vars(AWS_KEYS));
+                ignored.extend(Self::collect_set_env_vars(AZURE_KEYS));
+            }
+            CloudProvider::Azure => {
+                ignored.extend(Self::collect_set_env_vars(AWS_KEYS));
+                ignored.extend(Self::collect_set_env_vars(GCP_KEYS));
+            }
+        }
+
+        if ignored.is_empty() {
+            return;
+        }
+
+        ignored.sort();
+        ignored.dedup();
+
+        warn!(
+            provider = %selected_provider.as_str(),
+            ignored_env_vars = %ignored.join(","),
+            "Ignoring env vars for non-selected cloud providers"
+        );
+    }
+
+    fn collect_set_env_vars(keys: &[&str]) -> Vec<String> {
+        keys.iter()
+            .copied()
+            .filter_map(|key| Self::read_env(key).map(|_| key.to_string()))
+            .collect()
+    }
+
+    fn normalize(value: &str) -> Option<String> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn read_env(key: &str) -> Option<String> {
+        std::env::var(key).ok().and_then(|v| Self::normalize(&v))
+    }
+
+    fn read_bool_env(key: &str) -> bool {
+        Self::read_env(key)
+            .map(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::memory::InMemory;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    const TEST_ENV_KEYS: &[&str] = &[
+        "CLOUD_PROVIDER",
+        "STORAGE_BACKEND",
+        "STORAGE_CONTAINER",
+        "S3_BUCKET",
+        "S3_REGION",
+        "S3_ENDPOINT",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "GOOGLE_BUCKET",
+        "GOOGLE_BUCKET_NAME",
+        "AZURE_CONTAINER_NAME",
+        "METADATA_BACKEND",
+        "METADATA_CONTAINER",
+        "METADATA_BUCKET",
+        "METADATA_PREFIX",
+        "S3_METADATA_ALLOW_UNSAFE_OVERWRITE",
+    ];
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn with_env<F>(overrides: &[(&str, Option<&str>)], f: F)
+    where
+        F: FnOnce(),
+    {
+        let _guard = env_lock().lock().expect("env lock poisoned");
+        let mut saved: Vec<(&str, Option<OsString>)> = Vec::new();
+
+        for key in TEST_ENV_KEYS {
+            saved.push((key, std::env::var_os(key)));
+            // SAFETY: Tests hold a global mutex to serialize environment mutation.
+            unsafe { std::env::remove_var(key) };
+        }
+
+        for (key, value) in overrides {
+            match value {
+                Some(v) => {
+                    // SAFETY: Tests hold a global mutex to serialize environment mutation.
+                    unsafe { std::env::set_var(key, v) };
+                }
+                None => {
+                    // SAFETY: Tests hold a global mutex to serialize environment mutation.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+
+        f();
+
+        for (key, value) in saved {
+            match value {
+                Some(v) => {
+                    // SAFETY: Tests hold a global mutex to serialize environment mutation.
+                    unsafe { std::env::set_var(key, v) };
+                }
+                None => {
+                    // SAFETY: Tests hold a global mutex to serialize environment mutation.
+                    unsafe { std::env::remove_var(key) };
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_storage_config_defaults_to_memory() {
+        with_env(&[], || {
+            let cfg = ComponentFactory::resolve_storage_config(None, None, "tenant-a").unwrap();
+            assert_eq!(cfg.provider, CloudProvider::Memory);
+            assert_eq!(cfg.container, "cardinalsin-data");
+            assert_eq!(cfg.tenant_id, "tenant-a");
+        });
+    }
+
+    #[test]
+    fn resolve_storage_config_reads_cloud_provider() {
+        with_env(
+            &[
+                ("CLOUD_PROVIDER", Some("gcp")),
+                ("GOOGLE_BUCKET", Some("metrics-gcs")),
+            ],
+            || {
+                let cfg = ComponentFactory::resolve_storage_config(None, None, "tenant-a").unwrap();
+                assert_eq!(cfg.provider, CloudProvider::Gcp);
+                assert_eq!(cfg.container, "metrics-gcs");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_storage_config_uses_legacy_storage_backend_alias() {
+        with_env(
+            &[
+                ("STORAGE_BACKEND", Some("s3")),
+                ("S3_BUCKET", Some("legacy-bucket")),
+            ],
+            || {
+                let cfg = ComponentFactory::resolve_storage_config(None, None, "tenant-a").unwrap();
+                assert_eq!(cfg.provider, CloudProvider::Aws);
+                assert_eq!(cfg.container, "legacy-bucket");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_storage_config_prefers_cloud_provider_when_both_set() {
+        with_env(
+            &[
+                ("CLOUD_PROVIDER", Some("gcp")),
+                ("STORAGE_BACKEND", Some("s3")),
+                ("GOOGLE_BUCKET", Some("gcp-bucket")),
+                ("S3_BUCKET", Some("aws-bucket")),
+            ],
+            || {
+                let cfg = ComponentFactory::resolve_storage_config(None, None, "tenant-a").unwrap();
+                assert_eq!(cfg.provider, CloudProvider::Gcp);
+                assert_eq!(cfg.container, "gcp-bucket");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_storage_config_rejects_invalid_provider() {
+        with_env(&[("CLOUD_PROVIDER", Some("digitalocean"))], || {
+            let err = ComponentFactory::resolve_storage_config(None, None, "tenant-a")
+                .expect_err("invalid provider should fail");
+            assert!(
+                err.to_string().contains("invalid CLOUD_PROVIDER"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_storage_config_override_wins() {
+        with_env(
+            &[
+                ("CLOUD_PROVIDER", Some("aws")),
+                ("STORAGE_CONTAINER", Some("env-bucket")),
+            ],
+            || {
+                let cfg = ComponentFactory::resolve_storage_config(
+                    Some("azure"),
+                    Some("override-container"),
+                    "tenant-a",
+                )
+                .unwrap();
+                assert_eq!(cfg.provider, CloudProvider::Azure);
+                assert_eq!(cfg.container, "override-container");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_storage_container_aws_accepts_legacy_bucket() {
+        with_env(
+            &[
+                ("CLOUD_PROVIDER", Some("aws")),
+                ("S3_BUCKET", Some("legacy-aws-bucket")),
+            ],
+            || {
+                let cfg = ComponentFactory::resolve_storage_config(None, None, "tenant-a").unwrap();
+                assert_eq!(cfg.container, "legacy-aws-bucket");
+            },
+        );
+    }
+
+    #[test]
+    fn resolve_storage_container_aws_requires_container() {
+        with_env(&[("CLOUD_PROVIDER", Some("aws"))], || {
+            let err = ComponentFactory::resolve_storage_config(None, None, "tenant-a")
+                .expect_err("aws without container should fail");
+            assert!(
+                err.to_string()
+                    .contains("STORAGE_CONTAINER or S3_BUCKET required"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_storage_container_gcp_requires_container_or_google_bucket() {
+        with_env(&[("CLOUD_PROVIDER", Some("gcp"))], || {
+            let err = ComponentFactory::resolve_storage_config(None, None, "tenant-a")
+                .expect_err("gcp without bucket should fail");
+            assert!(
+                err.to_string().contains("GOOGLE_BUCKET"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn resolve_storage_container_azure_requires_container() {
+        with_env(&[("CLOUD_PROVIDER", Some("azure"))], || {
+            let err = ComponentFactory::resolve_storage_config(None, None, "tenant-a")
+                .expect_err("azure without container should fail");
+            assert!(
+                err.to_string().contains("AZURE_CONTAINER_NAME"),
+                "unexpected error: {err}"
+            );
+        });
+    }
+
+    #[test]
+    fn create_object_store_memory_works() {
+        with_env(
+            &[
+                ("CLOUD_PROVIDER", Some("memory")),
+                ("STORAGE_CONTAINER", Some("ignored")),
+            ],
+            || {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                let cfg = ComponentFactory::resolve_storage_config(None, None, "tenant-a").unwrap();
+                let store = rt.block_on(ComponentFactory::create_object_store_for(&cfg));
+                assert!(store.is_ok(), "memory store should succeed: {store:?}");
+            },
+        );
+    }
+
+    #[test]
+    fn create_metadata_client_local_backend() {
+        with_env(&[("METADATA_BACKEND", Some("local"))], || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+            let cfg = StorageConfig {
+                provider: CloudProvider::Memory,
+                container: "data".to_string(),
+                tenant_id: "tenant-a".to_string(),
+            };
+            let client = rt.block_on(ComponentFactory::create_metadata_client_for_storage(
+                store, &cfg,
+            ));
+            assert!(client.is_ok(), "local metadata should succeed");
+        });
+    }
+
+    #[test]
+    fn create_metadata_client_object_store_backend() {
+        with_env(
+            &[
+                ("METADATA_BACKEND", Some("object_store")),
+                ("METADATA_CONTAINER", Some("meta-bucket")),
+                ("METADATA_PREFIX", Some("metadata/")),
+            ],
+            || {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+                let cfg = StorageConfig {
+                    provider: CloudProvider::Memory,
+                    container: "data".to_string(),
+                    tenant_id: "tenant-a".to_string(),
+                };
+                let client = rt.block_on(ComponentFactory::create_metadata_client_for_storage(
+                    store, &cfg,
+                ));
+                assert!(client.is_ok(), "object_store metadata should succeed");
+            },
+        );
+    }
+
+    #[test]
+    fn create_metadata_client_accepts_s3_alias() {
+        with_env(
+            &[
+                ("METADATA_BACKEND", Some("s3")),
+                ("METADATA_BUCKET", Some("meta-bucket")),
+            ],
+            || {
+                let rt = tokio::runtime::Runtime::new().unwrap();
+                let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+                let cfg = StorageConfig {
+                    provider: CloudProvider::Memory,
+                    container: "data".to_string(),
+                    tenant_id: "tenant-a".to_string(),
+                };
+                let client = rt.block_on(ComponentFactory::create_metadata_client_for_storage(
+                    store, &cfg,
+                ));
+                assert!(
+                    client.is_ok(),
+                    "s3 alias should map to object_store metadata"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn create_metadata_client_rejects_unknown_backend() {
+        with_env(&[("METADATA_BACKEND", Some("sqlite"))], || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+            let cfg = StorageConfig {
+                provider: CloudProvider::Memory,
+                container: "data".to_string(),
+                tenant_id: "tenant-a".to_string(),
+            };
+            match rt.block_on(ComponentFactory::create_metadata_client_for_storage(
+                store, &cfg,
+            )) {
+                Ok(_) => panic!("unknown metadata backend should fail"),
+                Err(err) => assert!(
+                    err.to_string().contains("Unknown METADATA_BACKEND"),
+                    "unexpected error: {err}"
+                ),
+            }
+        });
     }
 }

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -12,7 +12,8 @@ pub use client::{MetadataClient, SplitState};
 pub use local::LocalMetadataClient;
 pub use predicates::{ColumnPredicate, PredicateValue};
 pub use s3::{
-    ChunkMetadataExtended, ColumnStats, MetadataCatalog, S3MetadataClient, S3MetadataConfig,
+    ChunkMetadataExtended, ColumnStats, MetadataCatalog, ObjectStoreMetadataClient,
+    ObjectStoreMetadataConfig, S3MetadataClient, S3MetadataConfig,
 };
 
 use crate::ingester::ChunkMetadata;

--- a/src/metadata/s3.rs
+++ b/src/metadata/s3.rs
@@ -128,7 +128,7 @@ pub struct ColumnStats {
 
 /// S3 metadata client configuration
 #[derive(Debug, Clone)]
-pub struct S3MetadataConfig {
+pub struct ObjectStoreMetadataConfig {
     /// S3 bucket name
     pub bucket: String,
     /// Prefix for metadata files
@@ -139,7 +139,7 @@ pub struct S3MetadataConfig {
     pub allow_unsafe_overwrite: bool,
 }
 
-impl Default for S3MetadataConfig {
+impl Default for ObjectStoreMetadataConfig {
     fn default() -> Self {
         Self {
             bucket: "cardinalsin-metadata".to_string(),
@@ -153,23 +153,23 @@ impl Default for S3MetadataConfig {
 /// S3-based metadata client
 ///
 /// Stores metadata durably on S3 with atomic operations
-pub struct S3MetadataClient {
+pub struct ObjectStoreMetadataClient {
     /// Object store for metadata storage
     object_store: Arc<dyn ObjectStore>,
     /// Configuration
-    config: S3MetadataConfig,
+    config: ObjectStoreMetadataConfig,
     /// Unified catalog cache with TTL
     catalog_cache: Arc<tokio::sync::RwLock<Option<(MetadataCatalog, Instant)>>>,
     /// Catalog cache TTL duration
     catalog_cache_ttl: Duration,
 }
 
-impl S3MetadataClient {
+impl ObjectStoreMetadataClient {
     /// Nanoseconds per hour constant
     const NANOS_PER_HOUR: i64 = 3_600_000_000_000;
 
     /// Create a new S3 metadata client
-    pub fn new(object_store: Arc<dyn ObjectStore>, config: S3MetadataConfig) -> Self {
+    pub fn new(object_store: Arc<dyn ObjectStore>, config: ObjectStoreMetadataConfig) -> Self {
         Self {
             object_store,
             config,
@@ -1061,7 +1061,7 @@ impl S3MetadataClient {
 }
 
 #[async_trait]
-impl MetadataClient for S3MetadataClient {
+impl MetadataClient for ObjectStoreMetadataClient {
     async fn register_chunk(&self, path: &str, metadata: &ChunkMetadata) -> Result<()> {
         // Use atomic registration with retry logic
         self.atomic_register_chunk(path, metadata).await
@@ -2065,3 +2065,7 @@ impl MetadataClient for S3MetadataClient {
             .any(|s| matches!(s.phase, SplitPhase::DualWrite | SplitPhase::Backfill)))
     }
 }
+
+pub type S3MetadataConfig = ObjectStoreMetadataConfig;
+
+pub type S3MetadataClient = ObjectStoreMetadataClient;

--- a/tests/wal_integration_tests.rs
+++ b/tests/wal_integration_tests.rs
@@ -15,7 +15,7 @@ use cardinalsin::ingester::{
 };
 use cardinalsin::metadata::LocalMetadataClient;
 use cardinalsin::schema::MetricSchema;
-use cardinalsin::StorageConfig;
+use cardinalsin::{CloudProvider, StorageConfig};
 use object_store::memory::InMemory;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -83,10 +83,9 @@ fn make_ingester(config: IngesterConfig) -> cardinalsin::ingester::Ingester {
     let metadata: Arc<dyn cardinalsin::metadata::MetadataClient> =
         Arc::new(LocalMetadataClient::new());
     let storage_config = StorageConfig {
+        provider: CloudProvider::Memory,
+        container: "test-bucket".to_string(),
         tenant_id: "test-tenant".to_string(),
-        bucket: "test-bucket".to_string(),
-        region: "us-east-1".to_string(),
-        endpoint: None,
     };
     let schema = MetricSchema::default_metrics();
     cardinalsin::ingester::Ingester::new(config, store, metadata, storage_config, schema)


### PR DESCRIPTION
Recover pending changes: migrate env/config from STORAGE_BACKEND+S3_BUCKET to CLOUD_PROVIDER+STORAGE_CONTAINER, add object-store metadata backend support, update binaries and compose wiring, and align query engine URL mapping/tests.