### PR TITLE
fix: pin Rust toolchain across Docker and CI to prevent GLIBC drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust stable
+      - name: Install Rust 1.93.0
         uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.0
+          components: rustfmt, clippy
 
       - name: Cache Rust artifacts
         uses: Swatinem/rust-cache@v2

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,5 +1,10 @@
+# Keep Rust and Debian releases aligned to avoid glibc mismatches between
+# builder and runtime images.
+ARG RUST_TOOLCHAIN=1.93.0
+ARG DEBIAN_RELEASE=bookworm
+
 # Build stage
-FROM rust:latest AS builder
+FROM rust:${RUST_TOOLCHAIN}-${DEBIAN_RELEASE} AS builder
 
 WORKDIR /app
 
@@ -41,7 +46,7 @@ RUN touch src/lib.rs src/bin/*.rs
 RUN cargo build --release --bins
 
 # Runtime stage
-FROM debian:bookworm-slim
+FROM debian:${DEBIAN_RELEASE}-slim
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \


### PR DESCRIPTION
## Summary
- pin Docker builder toolchain to `rust:1.93.0-bookworm`
- keep runtime on `debian:bookworm-slim` via shared `DEBIAN_RELEASE` arg to preserve glibc compatibility
- pin CI Rust toolchain to `1.93.0` with required `rustfmt` and `clippy` components

## Why
Latest `main` hit runtime failures (`GLIBC_2.39 not found`) when floating `rust:latest` advanced ahead of runtime glibc baseline.

## Validation
- `docker compose -f deploy/docker-compose.yml build ingester query compactor`
- `docker compose -f deploy/docker-compose.yml up -d`
- verified `ingester/query/compactor` stay up (no glibc loader errors)
- verified ingester WAL initializes at `/tmp/cardinalsin/wal`

Closes #108
