### PR TITLE
fix(prometheus): support POST requests with form-encoded body for Grafana

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -62,9 +62,9 @@ pub fn build_http_router(
 
         // Prometheus API
         .route("/api/v1/query", get(query::prometheus_api::instant_query))
-        .route("/api/v1/query", post(query::prometheus_api::instant_query))
+        .route("/api/v1/query", post(query::prometheus_api::instant_query_post))
         .route("/api/v1/query_range", get(query::prometheus_api::range_query))
-        .route("/api/v1/query_range", post(query::prometheus_api::range_query))
+        .route("/api/v1/query_range", post(query::prometheus_api::range_query_post))
         .route("/api/v1/labels", get(query::prometheus_api::labels))
         .route("/api/v1/label/:name/values", get(query::prometheus_api::label_values))
 

--- a/src/api/query/prometheus_api.rs
+++ b/src/api/query/prometheus_api.rs
@@ -8,7 +8,7 @@ use crate::api::ApiState;
 use arrow_array::Array;
 use arrow_schema::DataType;
 use axum::extract::{Path, Query, State};
-use axum::Json;
+use axum::{Form, Json};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -84,12 +84,30 @@ pub struct LabelValuesResponse {
     pub data: Vec<String>,
 }
 
-/// Instant query endpoint
+/// Instant query endpoint (GET)
 ///
-/// GET/POST /api/v1/query
+/// GET /api/v1/query
 pub async fn instant_query(
     State(state): State<ApiState>,
     Query(params): Query<InstantQueryParams>,
+) -> Json<PrometheusResponse> {
+    instant_query_inner(state, params).await
+}
+
+/// Instant query endpoint (POST)
+///
+/// POST /api/v1/query
+pub async fn instant_query_post(
+    State(state): State<ApiState>,
+    Form(params): Form<InstantQueryParams>,
+) -> Json<PrometheusResponse> {
+    instant_query_inner(state, params).await
+}
+
+/// Inner implementation for instant query (shared by GET and POST)
+async fn instant_query_inner(
+    state: ApiState,
+    params: InstantQueryParams,
 ) -> Json<PrometheusResponse> {
     // Transpile PromQL to SQL
     let sql = transpile_promql_instant(&params.query, params.time);
@@ -135,13 +153,28 @@ pub async fn instant_query(
     })
 }
 
-/// Range query endpoint
+/// Range query endpoint (GET)
 ///
-/// GET/POST /api/v1/query_range
+/// GET /api/v1/query_range
 pub async fn range_query(
     State(state): State<ApiState>,
     Query(params): Query<RangeQueryParams>,
 ) -> Json<PrometheusResponse> {
+    range_query_inner(state, params).await
+}
+
+/// Range query endpoint (POST)
+///
+/// POST /api/v1/query_range
+pub async fn range_query_post(
+    State(state): State<ApiState>,
+    Form(params): Form<RangeQueryParams>,
+) -> Json<PrometheusResponse> {
+    range_query_inner(state, params).await
+}
+
+/// Inner implementation for range query (shared by GET and POST)
+async fn range_query_inner(state: ApiState, params: RangeQueryParams) -> Json<PrometheusResponse> {
     // Transpile PromQL to SQL with time bucketing
     let sql = transpile_promql_range(&params.query, params.start, params.end, params.step);
 


### PR DESCRIPTION
## Summary
Fixes Prometheus API POST handlers to support Grafana's `application/x-www-form-urlencoded` request format.

## Problem
POST routes for `/api/v1/query` and `/api/v1/query_range` shared the same handlers as GET, using `Query<>` which only reads URL parameters. When Grafana sends POST requests with form-encoded bodies, parameters were silently empty, causing queries to fail.

## Solution
- Refactored `instant_query` and `range_query` into `_inner` functions
- Added `instant_query_post` and `range_query_post` handlers using `Form<>` extractor
- Updated routes in `mod.rs` to point POST requests to new form-based handlers
- Added E2E test harness methods: `query_prom_post`, `query_prom_range_post`
- Added 3 new tests to validate POST endpoint behavior

## Testing
- ✅ Code compiles successfully
- ✅ E2E test suite compiles
- 🧪 New tests: `test_prometheus_instant_query_post`, `test_prometheus_range_query_post`, `test_prometheus_post_with_labels`
- 📝 Tests are integration tests requiring docker-compose stack (marked with `#[ignore]`)

## Files Changed
- `src/api/query/prometheus_api.rs`: Added POST handlers with `Form<>` extractor
- `src/api/mod.rs`: Updated POST routes to use new handlers
- `tests/e2e/harness.rs`: Added POST test helper methods
- `tests/e2e/smoke/prometheus_api_tests.rs`: Added 3 POST endpoint tests

Closes #117