### PR TITLE
feat(prometheus): implement /api/v1/series and add filtering to label endpoints

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -65,8 +65,11 @@ pub fn build_http_router(
         .route("/api/v1/query", post(query::prometheus_api::instant_query_post))
         .route("/api/v1/query_range", get(query::prometheus_api::range_query))
         .route("/api/v1/query_range", post(query::prometheus_api::range_query_post))
-        .route("/api/v1/labels", get(query::prometheus_api::labels))
+        .route("/api/v1/labels", get(query::prometheus_api::labels_get))
+        .route("/api/v1/labels", post(query::prometheus_api::labels_post))
         .route("/api/v1/label/:name/values", get(query::prometheus_api::label_values))
+        .route("/api/v1/series", get(query::prometheus_api::series))
+        .route("/api/v1/series", post(query::prometheus_api::series_post))
 
         // Prometheus Remote Write
         .route("/api/v1/write", post(ingest::prometheus::handle_remote_write))


### PR DESCRIPTION
## Summary
Implements missing Grafana integration endpoints to fix issue #118.

Closes #118

## Changes

### 1. `/api/v1/series` endpoint (GET + POST)
- Returns list of series (unique label sets) matching selectors
- Accepts `match[]` (array of PromQL selectors), `start`, `end` params
- Used by Grafana for metric discovery and autocomplete
- Implements both GET and POST variants for Grafana compatibility

### 2. POST `/api/v1/labels` with filtering
- Extends existing labels endpoint with POST support
- Accepts `match[]`, `start`, `end` params to filter by time range and selectors
- Falls back to unfiltered query when no params provided (backward compatible)
- Used by Grafana to discover available labels for specific metrics

### 3. `/api/v1/label/{name}/values` with filtering
- Extends existing endpoint to accept `match[]`, `start`, `end` params
- Filters label values by time range and metric selectors
- Maintains backward compatibility with unfiltered queries
- Used by Grafana to populate label value dropdowns

## Implementation Details

- Added `SeriesQueryParams`, `SeriesFormParams`, `LabelsQueryParams`, `LabelsFormParams`, and `LabelValuesQueryParams` structs for parameter handling
- Created helper function `build_where_clauses()` to parse `match[]` selectors and time ranges into SQL WHERE clauses
- Reuses existing `parse_promql()` logic for selector parsing
- All three endpoints now support filtering by metric name, label matchers, and time ranges

## Testing

Added comprehensive e2e tests covering:
- `/api/v1/series` GET and POST variants
- `/api/v1/series` with time range filtering
- POST `/api/v1/labels` with filtering
- `/api/v1/label/{name}/values` with filtering

Tests validate response format, status codes, and data structure.

## Dependencies

This PR builds on the fixes from:
- #116 (PromQL-to-SQL transpilation) - merged
- #117 (POST handler support) - merged

## Grafana Compatibility

These endpoints enable full Grafana integration:
- ✅ Metric browser/discovery
- ✅ Label autocomplete
- ✅ Query builder with label filters
- ✅ Time range scoping for labels/series

🤖 Generated with [Claude Code](https://claude.com/claude-code)