### PR TITLE
docs: add worktree maintenance section with target cleanup command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,19 @@ cd deploy
 docker-compose up -d  # Starts MinIO, ingester, query node, compactor, Grafana
 ```
 
+### Worktree Maintenance
+When using git worktrees for parallel work, each worktree creates its own `target/` directory. Clean up when you have more than 10 worktrees:
+
+```bash
+# Remove all target directories (safe - cargo will rebuild as needed)
+find ~/code/cardinalsin -name "target" -type d -exec rm -rf {} +
+
+# Check worktree count
+git worktree list | wc -l
+```
+
+**Note**: This is safe because Cargo will rebuild dependencies as needed. Cleaning up saves disk space (each target dir can be 1-5GB).
+
 ## Architecture Overview
 
 ### Three-Tier System


### PR DESCRIPTION
## Summary
Add documentation for cleaning up `target/` directories when using multiple git worktrees to save disk space.

## Changes
- Added "Worktree Maintenance" section to CLAUDE.md
- Includes command to remove all target directories: `find ~/code/cardinalsin -name "target" -type d -exec rm -rf {} +`
- Includes command to check worktree count
- Guidance to clean up when >10 worktrees exist
- Safety note that Cargo will rebuild dependencies as needed

## Rationale
Each worktree creates its own `target/` directory (1-5GB each). With the project's policy of using worktrees for all tasks, disk space can accumulate quickly. This addition provides clear guidance on when and how to clean up safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)