### PR TITLE
fix(ingester): prevent panic when timestamp column is Int64

### DIFF
--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -728,29 +728,45 @@ impl Ingester {
     /// Extract minimum timestamp from batch
     fn extract_min_timestamp(&self, batch: &RecordBatch) -> Result<i64> {
         use arrow_array::cast::AsArray;
-        use arrow_array::types::TimestampNanosecondType;
+        use arrow_array::types::{Int64Type, TimestampNanosecondType};
 
         let col = batch
             .column_by_name("timestamp")
             .ok_or_else(|| Error::InvalidSchema("Missing timestamp column".into()))?;
 
-        let ts_array = col.as_primitive::<TimestampNanosecondType>();
-        let min = arrow::compute::min(ts_array).unwrap_or(0);
-        Ok(min)
+        if let Some(ts_array) = col.as_primitive_opt::<TimestampNanosecondType>() {
+            return Ok(arrow::compute::min(ts_array).unwrap_or(0));
+        }
+        if let Some(ts_array) = col.as_primitive_opt::<Int64Type>() {
+            return Ok(arrow::compute::min(ts_array).unwrap_or(0));
+        }
+
+        Err(Error::InvalidSchema(format!(
+            "Timestamp column must be Timestamp(Nanosecond) or Int64, got {:?}",
+            col.data_type()
+        )))
     }
 
     /// Extract maximum timestamp from batch
     fn extract_max_timestamp(&self, batch: &RecordBatch) -> Result<i64> {
         use arrow_array::cast::AsArray;
-        use arrow_array::types::TimestampNanosecondType;
+        use arrow_array::types::{Int64Type, TimestampNanosecondType};
 
         let col = batch
             .column_by_name("timestamp")
             .ok_or_else(|| Error::InvalidSchema("Missing timestamp column".into()))?;
 
-        let ts_array = col.as_primitive::<TimestampNanosecondType>();
-        let max = arrow::compute::max(ts_array).unwrap_or(0);
-        Ok(max)
+        if let Some(ts_array) = col.as_primitive_opt::<TimestampNanosecondType>() {
+            return Ok(arrow::compute::max(ts_array).unwrap_or(0));
+        }
+        if let Some(ts_array) = col.as_primitive_opt::<Int64Type>() {
+            return Ok(arrow::compute::max(ts_array).unwrap_or(0));
+        }
+
+        Err(Error::InvalidSchema(format!(
+            "Timestamp column must be Timestamp(Nanosecond) or Int64, got {:?}",
+            col.data_type()
+        )))
     }
 
     /// Subscribe to broadcast channel for streaming queries


### PR DESCRIPTION
## Summary
- accept both Timestamp(Nanosecond) and Int64 in ingester timestamp min/max extraction
- return Error::InvalidSchema for unsupported timestamp column types instead of panicking
- add regression tests that cover mixed timestamp ingest paths and unsupported-type error behavior

Closes #122.

## Testing
- CARGO_TARGET_DIR=/tmp/cardinalsin-target-issue122 cargo test --test coverage_gap_tests test_ingester_mixed_timestamp_column_types_no_panic -- --nocapture
- CARGO_TARGET_DIR=/tmp/cardinalsin-target-issue122 cargo test --test coverage_gap_tests test_ingester_unsupported_timestamp_type_returns_error -- --nocapture
