### PR TITLE
fix(ci): stop beads sync workflow from pushing directly to protected main

### DIFF
--- a/.github/scripts/sync-beads-closures.sh
+++ b/.github/scripts/sync-beads-closures.sh
@@ -20,6 +20,7 @@ fi
 
 pr_number="$(jq -r '.pull_request.number // empty' "$GITHUB_EVENT_PATH")"
 pr_url="$(jq -r '.pull_request.html_url // empty' "$GITHUB_EVENT_PATH")"
+base_ref="$(jq -r '.pull_request.base.ref // "main"' "$GITHUB_EVENT_PATH")"
 pr_title="$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")"
 pr_body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
 
@@ -83,6 +84,41 @@ fi
 git config user.name "github-actions[bot]"
 git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git add .beads/issues.jsonl
-git commit -m "chore(beads): sync closures for merged PR #${pr_number}"
-git push
+commit_title="chore(beads): sync closures for merged PR #${pr_number}"
+sync_branch="automation/beads-sync-pr-${pr_number}"
 
+git commit -m "${commit_title}"
+git checkout -B "${sync_branch}"
+if git ls-remote --exit-code --heads origin "${sync_branch}" >/dev/null 2>&1; then
+  git push --force-with-lease origin "${sync_branch}"
+else
+  git push --set-upstream origin "${sync_branch}"
+fi
+
+repo="${GITHUB_REPOSITORY:-}"
+if [[ -z "$repo" ]]; then
+  echo "GITHUB_REPOSITORY is missing; pushed '${sync_branch}' but cannot auto-create PR."
+  exit 0
+fi
+
+existing_pr_url="$(
+  gh pr list \
+    --repo "$repo" \
+    --state open \
+    --base "$base_ref" \
+    --head "$sync_branch" \
+    --json url \
+    --jq '.[0].url // empty'
+)"
+
+if [[ -n "$existing_pr_url" ]]; then
+  echo "Updated existing sync PR: ${existing_pr_url}"
+  exit 0
+fi
+
+gh pr create \
+  --repo "$repo" \
+  --base "$base_ref" \
+  --head "$sync_branch" \
+  --title "${commit_title}" \
+  --body "Automated Beads closure sync for merged PR #${pr_number} (${pr_url})."

--- a/.github/workflows/sync-beads-closures.yml
+++ b/.github/workflows/sync-beads-closures.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   issues: write
+  pull-requests: write
 
 jobs:
   sync:
@@ -23,4 +24,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bash .github/scripts/sync-beads-closures.sh
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Never auto-merge PRs without explicit user approval.** Do NOT use `gh pr merge --auto` or merge PRs immediately after opening them. PRs must remain open for review. Only merge when the user explicitly says to merge a specific PR.
 
+**Never run Beads closure sync directly on `main`.** Do not manually push Beads sync commits to `main` (protected branch). Use the existing `Sync Beads Closures` GitHub Action, which should update an automation branch and open/update a PR for review.
+
 **Always create a corresponding GitHub issue for each Beads task.** When creating a Beads issue (`bd create`), also run `gh issue create` with a matching title, description, and appropriate labels. Link the GitHub issue number back to the Beads issue (`bd update <id> --description "... External: gh-<number>"`). This ensures traceability across both tracking systems.
 
 ## Epic Delivery Workflow


### PR DESCRIPTION
## Summary
- update Beads sync script to push to an automation branch and open/update a PR instead of pushing directly to base branch
- add pull-requests: write permission for the sync workflow so it can create/update the automation PR
- add CLAUDE.md guidance to never run Beads closure sync directly on main

## Why
Recent Sync Beads Closures runs failed with GH006 protected-branch errors because the workflow attempted a direct push to main.

## Validation
- bash -n .github/scripts/sync-beads-closures.sh
- synthetic event smoke test for no-closure path