### PR TITLE
fix(query): dedup split dual-write by full row identity

### DIFF
--- a/src/query/dedup.rs
+++ b/src/query/dedup.rs
@@ -5,7 +5,7 @@
 //! so queries return each row exactly once.
 
 use arrow::compute::filter_record_batch;
-use arrow_array::cast::AsArray;
+use arrow::util::display::array_value_to_string;
 use arrow_array::BooleanArray;
 use arrow_array::{Array, RecordBatch};
 use std::collections::HashSet;
@@ -14,8 +14,9 @@ use crate::Result;
 
 /// Deduplicate rows across multiple record batches.
 ///
-/// Uses (timestamp_nanos, metric_name) as the dedup key. The first occurrence
-/// of each key is kept; subsequent duplicates are filtered out.
+/// Uses full row identity as the dedup key, requiring `timestamp` and
+/// `metric_name` to be present. This avoids false positives where rows share
+/// timestamp+metric but differ by labels or value.
 ///
 /// This is applied at query time when any shard involved in the result set
 /// is in a dual-write split phase.
@@ -24,76 +25,41 @@ pub fn dedup_batches(batches: Vec<RecordBatch>) -> Result<Vec<RecordBatch>> {
         return Ok(batches);
     }
 
-    let mut seen: HashSet<(i64, String)> = HashSet::new();
+    let mut seen: HashSet<String> = HashSet::new();
     let mut result = Vec::with_capacity(batches.len());
 
     for batch in &batches {
-        let ts_col = batch.column_by_name("timestamp");
-        let metric_col = batch.column_by_name("metric_name");
-
         // If the batch doesn't have both columns, we can't dedup — pass through
-        let (ts_col, metric_col) = match (ts_col, metric_col) {
-            (Some(t), Some(m)) => (t, m),
+        match (
+            batch.column_by_name("timestamp"),
+            batch.column_by_name("metric_name"),
+        ) {
+            (Some(_), Some(_)) => {}
             _ => {
                 result.push(batch.clone());
                 continue;
             }
-        };
+        }
 
-        // Try to get timestamp as nanosecond or int64
-        let ts_values: Vec<Option<i64>> = if let Some(ts_arr) =
-            ts_col.as_primitive_opt::<arrow_array::types::TimestampNanosecondType>()
-        {
-            (0..batch.num_rows())
-                .map(|i| {
-                    if ts_arr.is_null(i) {
-                        None
-                    } else {
-                        Some(ts_arr.value(i))
-                    }
-                })
-                .collect()
-        } else if let Some(ts_arr) = ts_col.as_primitive_opt::<arrow_array::types::Int64Type>() {
-            (0..batch.num_rows())
-                .map(|i| {
-                    if ts_arr.is_null(i) {
-                        None
-                    } else {
-                        Some(ts_arr.value(i))
-                    }
-                })
-                .collect()
-        } else {
-            // Can't interpret timestamp column — pass through
-            result.push(batch.clone());
-            continue;
-        };
-
-        let metric_arr = match metric_col.as_string_opt::<i32>() {
-            Some(arr) => arr,
-            None => {
-                result.push(batch.clone());
-                continue;
-            }
-        };
+        // Sort by column name to keep key construction stable even if projected
+        // column order differs across batches.
+        let mut key_columns: Vec<(String, usize)> = batch
+            .schema()
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(idx, field)| (field.name().to_string(), idx))
+            .collect();
+        key_columns.sort_by(|a, b| a.0.cmp(&b.0));
 
         // Build keep mask
         let mut keep = vec![true; batch.num_rows()];
         let mut any_dropped = false;
 
-        for i in 0..batch.num_rows() {
-            let ts = match ts_values[i] {
-                Some(v) => v,
-                None => continue, // Keep nulls
-            };
-            let metric = if metric_arr.is_null(i) {
-                String::new()
-            } else {
-                metric_arr.value(i).to_string()
-            };
-
-            if !seen.insert((ts, metric)) {
-                keep[i] = false;
+        for (i, keep_row) in keep.iter_mut().enumerate() {
+            let key = build_row_key(batch, i, &key_columns);
+            if !seen.insert(key) {
+                *keep_row = false;
                 any_dropped = true;
             }
         }
@@ -110,6 +76,34 @@ pub fn dedup_batches(batches: Vec<RecordBatch>) -> Result<Vec<RecordBatch>> {
     }
 
     Ok(result)
+}
+
+fn build_row_key(batch: &RecordBatch, row: usize, key_columns: &[(String, usize)]) -> String {
+    let mut key = String::new();
+    key.reserve(key_columns.len() * 32);
+
+    for (column_name, column_idx) in key_columns {
+        let value = cell_value_for_key(batch.column(*column_idx).as_ref(), row);
+        key.push_str(&column_name.len().to_string());
+        key.push(':');
+        key.push_str(column_name);
+        key.push('=');
+        key.push_str(&value.len().to_string());
+        key.push(':');
+        key.push_str(&value);
+        key.push('|');
+    }
+
+    key
+}
+
+fn cell_value_for_key(array: &dyn Array, row: usize) -> String {
+    if array.is_null(row) {
+        return "<null>".to_string();
+    }
+
+    array_value_to_string(array, row)
+        .unwrap_or_else(|_| format!("<unprintable:{:?}>", array.data_type()))
 }
 
 #[cfg(test)]
@@ -131,6 +125,31 @@ mod tests {
             vec![
                 Arc::new(Int64Array::from(timestamps.to_vec())),
                 Arc::new(StringArray::from(metrics.to_vec())),
+                Arc::new(Float64Array::from(values.to_vec())),
+            ],
+        )
+        .unwrap()
+    }
+
+    fn make_labeled_batch(
+        timestamps: &[i64],
+        metrics: &[&str],
+        hosts: &[&str],
+        values: &[f64],
+    ) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("host", DataType::Utf8, true),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(timestamps.to_vec())),
+                Arc::new(StringArray::from(metrics.to_vec())),
+                Arc::new(StringArray::from(hosts.to_vec())),
                 Arc::new(Float64Array::from(values.to_vec())),
             ],
         )
@@ -191,6 +210,72 @@ mod tests {
         assert_eq!(
             total_rows, 3,
             "Different metrics at same timestamp are not duplicates"
+        );
+    }
+
+    #[test]
+    fn test_dedup_same_timestamp_metric_different_labels() {
+        let batch = make_labeled_batch(
+            &[100, 100],
+            &["cpu", "cpu"],
+            &["host-a", "host-b"],
+            &[1.0, 1.0],
+        );
+
+        let result = dedup_batches(vec![batch]).unwrap();
+
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            total_rows, 2,
+            "Rows with same timestamp+metric but different labels are distinct series"
+        );
+    }
+
+    #[test]
+    fn test_dedup_same_timestamp_metric_labels_different_values() {
+        let batch = make_labeled_batch(
+            &[100, 100],
+            &["cpu", "cpu"],
+            &["host-a", "host-a"],
+            &[1.0, 2.0],
+        );
+
+        let result = dedup_batches(vec![batch]).unwrap();
+
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            total_rows, 2,
+            "Rows with same timestamp+metric+labels but different values are distinct rows"
+        );
+    }
+
+    #[test]
+    fn test_dedup_exact_rows_with_different_column_order() {
+        let batch1 = make_labeled_batch(&[100], &["cpu"], &["host-a"], &[1.0]);
+
+        let reordered_schema = Arc::new(Schema::new(vec![
+            Field::new("metric_name", DataType::Utf8, false),
+            Field::new("host", DataType::Utf8, true),
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        let batch2 = RecordBatch::try_new(
+            reordered_schema,
+            vec![
+                Arc::new(StringArray::from(vec!["cpu"])),
+                Arc::new(StringArray::from(vec!["host-a"])),
+                Arc::new(Int64Array::from(vec![100])),
+                Arc::new(Float64Array::from(vec![1.0])),
+            ],
+        )
+        .unwrap();
+
+        let result = dedup_batches(vec![batch1, batch2]).unwrap();
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            total_rows, 1,
+            "Exact duplicates should be removed even if column order differs across batches"
         );
     }
 }


### PR DESCRIPTION
## Summary
- switch split dual-write query dedup from (timestamp, metric_name) keys to deterministic full-row identity keys
- keep dedup deterministic across batch orderings by sorting columns by name before key construction
- add regression tests for same timestamp+metric with different labels/values and for differing column order

## Validation
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test query::dedup::tests --lib

Closes #143