### PR TITLE
Wire adaptive indexing controller into query runtime

### DIFF
--- a/src/adaptive_index/mod.rs
+++ b/src/adaptive_index/mod.rs
@@ -36,6 +36,8 @@ pub struct AdaptiveIndexConfig {
     pub removal_grace_period: Duration,
     /// Statistics window duration
     pub stats_window: Duration,
+    /// Controller loop interval
+    pub check_interval: Duration,
 }
 
 impl Default for AdaptiveIndexConfig {
@@ -48,6 +50,7 @@ impl Default for AdaptiveIndexConfig {
             unused_days_threshold: 30,
             removal_grace_period: Duration::from_secs(7 * 24 * 3600), // 7 days
             stats_window: Duration::from_secs(48 * 3600),             // 48 hours
+            check_interval: Duration::from_secs(300),                 // Check every 5 minutes
         }
     }
 }
@@ -75,6 +78,7 @@ pub struct AdaptiveIndexController {
 impl AdaptiveIndexController {
     /// Create a new adaptive index controller
     pub fn new(config: AdaptiveIndexConfig) -> Self {
+        let check_interval = config.check_interval;
         let stats_collector = Arc::new(QueryStatsCollector::new(config.stats_window));
         let recommendation_engine = IndexRecommendationEngine::new(config.clone());
         let lifecycle_manager = IndexLifecycleManager::new(config.clone());
@@ -85,7 +89,7 @@ impl AdaptiveIndexController {
             recommendation_engine,
             lifecycle_manager,
             tenant_configs: std::sync::RwLock::new(std::collections::HashMap::new()),
-            check_interval: Duration::from_secs(300), // Check every 5 minutes
+            check_interval,
         }
     }
 

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -2,6 +2,7 @@
 //!
 //! Stateless query node that executes queries via DataFusion.
 
+use cardinalsin::adaptive_index::{AdaptiveIndexConfig, AdaptiveIndexController};
 use cardinalsin::api;
 use cardinalsin::config::ComponentFactory;
 use cardinalsin::ingester::{Ingester, IngesterConfig};
@@ -61,6 +62,34 @@ struct Args {
     /// Log level
     #[arg(long, default_value = "info")]
     log_level: String,
+
+    /// Enable adaptive indexing controller
+    #[arg(long, env = "ADAPTIVE_INDEXING_ENABLED", default_value = "false")]
+    adaptive_indexing_enabled: bool,
+
+    /// Adaptive indexing controller interval in seconds
+    #[arg(
+        long,
+        env = "ADAPTIVE_INDEX_CHECK_INTERVAL_SECS",
+        default_value = "300"
+    )]
+    adaptive_index_check_interval_secs: u64,
+
+    /// Minimum filter uses before recommending an index
+    #[arg(
+        long,
+        env = "ADAPTIVE_INDEX_MIN_FILTER_THRESHOLD",
+        default_value = "100"
+    )]
+    adaptive_index_min_filter_threshold: u64,
+
+    /// Recommendation score threshold for creating indexes
+    #[arg(long, env = "ADAPTIVE_INDEX_SCORE_THRESHOLD", default_value = "1.0")]
+    adaptive_index_score_threshold: f64,
+
+    /// Maximum index recommendations per controller cycle
+    #[arg(long, env = "ADAPTIVE_INDEX_MAX_RECOMMENDATIONS", default_value = "5")]
+    adaptive_index_max_recommendations: usize,
 }
 
 #[tokio::main]
@@ -92,16 +121,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
+    let mut adaptive_controller: Option<Arc<AdaptiveIndexController>> = None;
+
     // Create query node
-    let query_node = Arc::new(
-        QueryNode::new(
-            query_config,
-            object_store.clone(),
-            metadata.clone(),
-            storage_config.clone(),
-        )
-        .await?,
-    );
+    let mut query_node = QueryNode::new(
+        query_config,
+        object_store.clone(),
+        metadata.clone(),
+        storage_config.clone(),
+    )
+    .await?;
+
+    if args.adaptive_indexing_enabled {
+        let adaptive_config = AdaptiveIndexConfig {
+            min_filter_threshold: args.adaptive_index_min_filter_threshold,
+            score_threshold: args.adaptive_index_score_threshold,
+            max_recommendations_per_cycle: args.adaptive_index_max_recommendations,
+            check_interval: std::time::Duration::from_secs(args.adaptive_index_check_interval_secs),
+            ..AdaptiveIndexConfig::default()
+        };
+
+        let controller = Arc::new(AdaptiveIndexController::new(adaptive_config.clone()));
+        query_node = query_node.with_adaptive_indexing(controller.clone());
+        adaptive_controller = Some(controller);
+
+        info!(
+            check_interval_secs = args.adaptive_index_check_interval_secs,
+            min_filter_threshold = adaptive_config.min_filter_threshold,
+            score_threshold = adaptive_config.score_threshold,
+            max_recommendations_per_cycle = adaptive_config.max_recommendations_per_cycle,
+            "Adaptive indexing enabled"
+        );
+    } else {
+        info!("Adaptive indexing disabled");
+    }
+
+    let query_node = Arc::new(query_node);
 
     // Create a dummy ingester for the API (in production, query nodes don't ingest)
     let ingester = Arc::new(Ingester::new(
@@ -122,9 +177,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let http_shutdown = shutdown_rx.clone();
     let grpc_shutdown = shutdown_rx.clone();
+    let adaptive_shutdown = shutdown_rx.clone();
     tokio::spawn(async move {
         shutdown_signal().await;
         let _ = shutdown_tx.send(true);
+    });
+
+    let adaptive_task = adaptive_controller.map(|controller| {
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = controller.run() => {},
+                _ = wait_for_shutdown(adaptive_shutdown) => {},
+            }
+        })
     });
 
     info!(
@@ -143,6 +208,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let grpc_server = api::grpc::run_query_grpc_server(grpc_addr, query_node, grpc_shutdown);
     tokio::try_join!(http_server, grpc_server)?;
+
+    if let Some(adaptive_task) = adaptive_task {
+        adaptive_task.abort();
+        let _ = adaptive_task.await;
+    }
 
     info!("Query node shutting down");
 

--- a/src/query/engine.rs
+++ b/src/query/engine.rs
@@ -22,6 +22,7 @@ use parking_lot::RwLock;
 use std::collections::{BTreeSet, HashSet};
 use std::future::Future;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Mutex;
 
 /// Query engine powered by DataFusion
@@ -266,6 +267,7 @@ impl QueryEngine {
         let df = self.ctx.sql(sql).await?;
         let plan = df.logical_plan();
         let filter_columns = Self::extract_filter_columns(plan);
+        let groupby_columns = Self::extract_groupby_columns(plan);
 
         // 2. Get visible indexes for this tenant
         let tenant_string = tenant_id.to_string();
@@ -281,9 +283,22 @@ impl QueryEngine {
         }
 
         // 4. Execute query (DataFusion handles predicate pushdown automatically)
+        let query_started = Instant::now();
         let batches = df.collect().await?;
+        let query_time = query_started.elapsed();
 
-        // 5. Track would-have-helped for invisible indexes
+        // 5. Record stats used by the recommendation cycle.
+        for column in &filter_columns {
+            // Start with conservative selectivity until physical index scans
+            // can measure this directly from filtered row counts.
+            index_controller.record_filter(&tenant_string, column, 0.1, query_time);
+        }
+
+        if !groupby_columns.is_empty() {
+            index_controller.record_groupby(&tenant_string, &groupby_columns);
+        }
+
+        // 6. Track would-have-helped for invisible indexes
         let invisible_indexes = index_controller
             .lifecycle_manager
             .get_invisible_indexes(&tenant_string);
@@ -308,6 +323,15 @@ impl QueryEngine {
         columns
     }
 
+    /// Extract GROUP BY columns from a logical plan
+    fn extract_groupby_columns(plan: &LogicalPlan) -> Vec<String> {
+        let mut columns = Vec::new();
+        Self::extract_groupby_columns_recursive(plan, &mut columns);
+        columns.sort();
+        columns.dedup();
+        columns
+    }
+
     /// Recursively extract filter columns from a logical plan
     fn extract_filter_columns_recursive(plan: &LogicalPlan, columns: &mut Vec<String>) {
         match plan {
@@ -326,6 +350,31 @@ impl QueryEngine {
             }
             LogicalPlan::Aggregate(agg) => {
                 Self::extract_filter_columns_recursive(&agg.input, columns);
+            }
+            _ => {}
+        }
+    }
+
+    /// Recursively extract GROUP BY columns from a logical plan
+    fn extract_groupby_columns_recursive(plan: &LogicalPlan, columns: &mut Vec<String>) {
+        match plan {
+            LogicalPlan::Aggregate(agg) => {
+                for expr in &agg.group_expr {
+                    Self::extract_columns_from_expr(expr, columns);
+                }
+                Self::extract_groupby_columns_recursive(&agg.input, columns);
+            }
+            LogicalPlan::Filter(filter) => {
+                Self::extract_groupby_columns_recursive(&filter.input, columns);
+            }
+            LogicalPlan::Projection(proj) => {
+                Self::extract_groupby_columns_recursive(&proj.input, columns);
+            }
+            LogicalPlan::Sort(sort) => {
+                Self::extract_groupby_columns_recursive(&sort.input, columns);
+            }
+            LogicalPlan::Limit(limit) => {
+                Self::extract_groupby_columns_recursive(&limit.input, columns);
             }
             _ => {}
         }

--- a/tests/adaptive_indexing_tests.rs
+++ b/tests/adaptive_indexing_tests.rs
@@ -242,6 +242,44 @@ async fn test_query_node_integration() {
     assert!(Arc::strong_count(&index_controller) >= 2); // query_node + our reference
 }
 
+/// Test query execution records adaptive stats for filter and group-by columns
+#[tokio::test]
+async fn test_query_records_adaptive_stats() {
+    let object_store = Arc::new(InMemory::new());
+    let metadata = Arc::new(LocalMetadataClient::new());
+    let storage_config = StorageConfig::default();
+
+    let index_controller = Arc::new(AdaptiveIndexController::new(AdaptiveIndexConfig::default()));
+
+    let query_node = QueryNode::new(
+        QueryConfig::default(),
+        object_store,
+        metadata,
+        storage_config,
+    )
+    .await
+    .unwrap()
+    .with_adaptive_indexing(index_controller.clone());
+
+    let tenant_id = "tenant-stats".to_string();
+    let sql = "SELECT service, COUNT(*) FROM metrics WHERE host = 'web-01' GROUP BY service";
+
+    let _ = query_node.query_for_tenant(sql, &tenant_id).await.unwrap();
+
+    let stats = index_controller
+        .get_tenant_stats(&tenant_id)
+        .expect("expected adaptive stats after query");
+    assert!(
+        stats.column_filter_stats.contains_key("host"),
+        "expected filter stats for host predicate"
+    );
+    assert_eq!(
+        stats.groupby_stats.get("service"),
+        Some(&1),
+        "expected one GROUP BY observation for service"
+    );
+}
+
 /// Test filter statistics collection
 #[tokio::test]
 async fn test_filter_statistics_collection() {


### PR DESCRIPTION
## Summary
- wire adaptive indexing controller startup into `cardinalsin-query` behind explicit CLI/env toggles
- add adaptive controller loop interval to `AdaptiveIndexConfig` and honor it at runtime
- record filter and GROUP BY usage stats during `execute_with_indexes` query execution
- add integration coverage asserting adaptive stats are captured from real query execution

## Config
- `ADAPTIVE_INDEXING_ENABLED` (default: `false`)
- `ADAPTIVE_INDEX_CHECK_INTERVAL_SECS` (default: `300`)
- `ADAPTIVE_INDEX_MIN_FILTER_THRESHOLD` (default: `100`)
- `ADAPTIVE_INDEX_SCORE_THRESHOLD` (default: `1.0`)
- `ADAPTIVE_INDEX_MAX_RECOMMENDATIONS` (default: `5`)

## Validation
- `cargo test --test adaptive_indexing_tests`
- `cargo check --bin cardinalsin-query`

Closes gh-60