### PR TITLE
feat(sharding): make ingest and query paths shard-aware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "twox-hash 2.1.2",
  "url",
  "uuid",
  "wiremock",
@@ -5168,6 +5169,9 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ rand = "0.8"
 itertools = "0.13"
 num_cpus = "1"
 regex = "1"
+twox-hash = "2"
 
 # Configuration
 clap = { version = "4", features = ["derive", "env"] }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -46,7 +46,12 @@ RUN touch src/lib.rs src/bin/*.rs
 RUN cargo build --release --bins
 
 # Runtime stage
-FROM debian:${DEBIAN_RELEASE}-slim
+#
+# Rust 1.93's distributed linux toolchain produces binaries that require a
+# newer glibc than `debian:bookworm-slim` provides in CI. Reuse the same Rust
+# image family for runtime so the shipped binaries and runtime libc stay in
+# lockstep.
+FROM rust:${RUST_TOOLCHAIN}-${DEBIAN_RELEASE} AS runtime
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -46,12 +46,7 @@ RUN touch src/lib.rs src/bin/*.rs
 RUN cargo build --release --bins
 
 # Runtime stage
-#
-# Rust 1.93's distributed linux toolchain produces binaries that require a
-# newer glibc than `debian:bookworm-slim` provides in CI. Reuse the same Rust
-# image family for runtime so the shipped binaries and runtime libc stay in
-# lockstep.
-FROM rust:${RUST_TOOLCHAIN}-${DEBIAN_RELEASE} AS runtime
+FROM debian:${DEBIAN_RELEASE}-slim
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -705,7 +705,7 @@ impl Ingester {
             max_timestamp: self.extract_max_timestamp(&combined)?,
             row_count: combined.num_rows() as u64,
             size_bytes: parquet_size,
-            shard_id: Some(shard_id.to_string()),
+            shard_id: shard_id.to_string(),
         };
         self.metadata.register_chunk(&path, &chunk_metadata).await?;
 
@@ -895,8 +895,7 @@ pub struct ChunkMetadata {
     pub max_timestamp: i64,
     pub row_count: u64,
     pub size_bytes: u64,
-    #[serde(default)]
-    pub shard_id: Option<String>,
+    pub shard_id: String,
 }
 
 /// Buffer statistics

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -25,11 +25,14 @@ pub use wal::{load_flushed_seq, persist_flushed_seq, WalConfig, WalSyncMode, Wri
 use crate::clock::BoundedClock;
 use crate::metadata::MetadataClient;
 use crate::schema::MetricSchema;
-use crate::sharding::{HotShardConfig, ShardKey, ShardMonitor};
+use crate::sharding::{
+    key_in_range, next_key_bytes, HotShardConfig, ShardKey, ShardMetadata, ShardMonitor, ShardState,
+};
 use crate::{Error, Result, StorageConfig};
 
 use arrow_array::RecordBatch;
 use object_store::ObjectStore;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -91,8 +94,8 @@ impl Default for IngesterConfig {
 pub struct Ingester {
     /// Configuration
     config: IngesterConfig,
-    /// Write buffer
-    buffer: Arc<RwLock<WriteBuffer>>,
+    /// Write buffers grouped by shard
+    buffers: Arc<RwLock<HashMap<String, WriteBuffer>>>,
     /// Object storage client
     object_store: Arc<dyn ObjectStore>,
     /// Metadata client
@@ -146,7 +149,7 @@ impl Ingester {
 
         Self {
             config,
-            buffer: Arc::new(RwLock::new(WriteBuffer::new())),
+            buffers: Arc::new(RwLock::new(HashMap::new())),
             object_store,
             metadata,
             parquet_writer: ParquetWriter::new(),
@@ -183,7 +186,7 @@ impl Ingester {
 
         Self {
             config,
-            buffer: Arc::new(RwLock::new(WriteBuffer::new())),
+            buffers: Arc::new(RwLock::new(HashMap::new())),
             object_store,
             metadata,
             parquet_writer: ParquetWriter::new(),
@@ -231,32 +234,7 @@ impl Ingester {
                     match entry.batches() {
                         Ok(batches) => {
                             for batch in batches {
-                                let mut pending_batch = Some(batch);
-                                loop {
-                                    let mut buffer = self.buffer.write().await;
-                                    let incoming = pending_batch.as_ref().ok_or_else(|| {
-                                        Error::Internal("Missing pending batch".to_string())
-                                    })?;
-
-                                    // Keep recovery buffer schema-homogeneous so future flushes do not fail.
-                                    if !buffer.schema_compatible(incoming) {
-                                        let existing = buffer.take();
-                                        drop(buffer);
-                                        // Advance WAL seq before flush so flush_batches persists
-                                        // the correct sequence. Without this, a crash after the
-                                        // flush but before line `self.last_wal_seq.store(max_seq)`
-                                        // would replay already-flushed entries on next recovery.
-                                        self.last_wal_seq.store(max_seq, Ordering::Release);
-                                        self.flush_batches(existing).await?;
-                                        continue;
-                                    }
-
-                                    let incoming = pending_batch.take().ok_or_else(|| {
-                                        Error::Internal("Missing pending batch".to_string())
-                                    })?;
-                                    buffer.append(incoming)?;
-                                    break;
-                                }
+                                self.append_batch_to_shard_buffers(batch).await?;
                                 replayed += 1;
                             }
                             if entry.seq > max_seq {
@@ -269,7 +247,7 @@ impl Ingester {
                     }
                 }
                 self.last_wal_seq.store(max_seq, Ordering::Release);
-                let buffer_rows = self.buffer.read().await.row_count();
+                let buffer_rows = self.total_buffer_rows().await;
                 info!(
                     replayed_entries = replayed,
                     buffer_rows,
@@ -298,25 +276,9 @@ impl Ingester {
     /// behavior — fsync runs asynchronously on the configured interval.
     pub async fn write(&self, batch: RecordBatch) -> Result<()> {
         let start_time = std::time::Instant::now();
-        let batch_size = batch.get_array_memory_size();
         let row_count = batch.num_rows() as u64;
 
-        // Compute shard key for this batch (for monitoring)
-        let shard_id = self.compute_shard_id(&batch);
         let result = async {
-            // Check if shard is being split - if so, use dual-write
-            if let Some(split_state) = self.metadata.get_split_state(&shard_id).await? {
-                use crate::sharding::SplitPhase;
-                if matches!(
-                    split_state.phase,
-                    SplitPhase::DualWrite | SplitPhase::Backfill
-                ) {
-                    info!("Shard {} is splitting, enabling dual-write mode", shard_id);
-                    return self.write_with_split_awareness(batch, &shard_id).await;
-                }
-            }
-
-            // Normal single-write path
             if let Some(wal) = self.wal.as_ref() {
                 let seq = match wal.lock().await.append(&batch).await {
                     Ok(seq) => {
@@ -338,12 +300,32 @@ impl Ingester {
                 }
             }
 
-            self.append_to_buffer_and_maybe_flush(batch, batch_size).await?;
-
-            // Record write metrics for hot shard detection
+            let shard_batches = self.partition_batch_by_shard(&batch).await?;
             let write_latency = start_time.elapsed();
-            self.shard_monitor
-                .record_write(&shard_id, batch_size, write_latency);
+
+            for (shard_id, shard_batch) in shard_batches {
+                let shard_batch_size = shard_batch.get_array_memory_size();
+
+                if let Some(split_state) = self.metadata.get_split_state(&shard_id).await? {
+                    use crate::sharding::SplitPhase;
+                    if matches!(
+                        split_state.phase,
+                        SplitPhase::DualWrite | SplitPhase::Backfill
+                    ) {
+                        info!("Shard {} is splitting, enabling dual-write mode", shard_id);
+                        self.write_with_split_awareness(shard_batch, &shard_id).await?;
+                    } else {
+                        self.append_batch_to_specific_shard(&shard_id, shard_batch)
+                            .await?;
+                    }
+                } else {
+                    self.append_batch_to_specific_shard(&shard_id, shard_batch)
+                        .await?;
+                }
+
+                self.shard_monitor
+                    .record_write(&shard_id, shard_batch_size, write_latency);
+            }
 
             Ok(())
         }
@@ -362,29 +344,8 @@ impl Ingester {
             .await?
             .ok_or_else(|| Error::Internal("Split state disappeared".to_string()))?;
 
-        if let Some(wal) = self.wal.as_ref() {
-            let seq = match wal.lock().await.append(&batch).await {
-                Ok(seq) => {
-                    telemetry::record_wal_operation("append", "ok");
-                    seq
-                }
-                Err(e) => {
-                    telemetry::record_wal_operation("append", "error");
-                    return Err(e);
-                }
-            };
-            self.last_wal_seq.store(seq, Ordering::Release);
-        } else if self.config.wal.enabled {
-            telemetry::record_wal_operation("append", "error");
-            if !self.wal_warned.swap(true, Ordering::Relaxed) {
-                warn!(
-                    "WAL is enabled but not initialized - call ensure_wal() for crash durability"
-                );
-            }
-        }
-
         // Write to old shard first (for consistency during transition)
-        self.append_to_buffer_and_maybe_flush(batch.clone(), batch.get_array_memory_size())
+        self.append_batch_to_specific_shard(shard_id, batch.clone())
             .await?;
 
         // Split batch by key range and write to new shards
@@ -396,7 +357,7 @@ impl Ingester {
                 batch_a.num_rows(),
                 split_state.new_shards[0]
             );
-            self.write_to_shard(&batch_a, &split_state.new_shards[0])
+            self.append_batch_to_specific_shard(&split_state.new_shards[0], batch_a)
                 .await?;
         }
 
@@ -406,83 +367,25 @@ impl Ingester {
                 batch_b.num_rows(),
                 split_state.new_shards[1]
             );
-            self.write_to_shard(&batch_b, &split_state.new_shards[1])
+            self.append_batch_to_specific_shard(&split_state.new_shards[1], batch_b)
                 .await?;
         }
 
         Ok(())
     }
 
-    /// Write a batch directly to a specific shard (bypass buffer)
-    async fn write_to_shard(&self, batch: &RecordBatch, shard_id: &str) -> Result<()> {
-        // Convert batch to Parquet
-        let parquet_bytes = self.parquet_writer.write_batch(batch)?;
-        let parquet_size = parquet_bytes.len() as u64;
-
-        // Generate path for this shard
-        let now = self.clock.now();
-        let uuid = uuid::Uuid::new_v4();
-        let path = format!(
-            "{}/data/shard={}/year={}/month={:02}/day={:02}/hour={:02}/chunk_{}.parquet",
-            self.storage_config.tenant_id,
-            shard_id,
-            now.format("%Y"),
-            now.format("%m"),
-            now.format("%d"),
-            now.format("%H"),
-            uuid
-        );
-
-        // Upload to object storage
-        self.object_store
-            .put(&path.clone().into(), parquet_bytes.into())
-            .await?;
-
-        // Register in metadata store
-        let chunk_metadata = ChunkMetadata {
-            path: path.clone(),
-            min_timestamp: self.extract_min_timestamp(batch)?,
-            max_timestamp: self.extract_max_timestamp(batch)?,
-            row_count: batch.num_rows() as u64,
-            size_bytes: parquet_size,
-        };
-        self.metadata.register_chunk(&path, &chunk_metadata).await?;
-
-        Ok(())
-    }
-
-    /// Split a batch by key range (based on timestamp split point)
+    /// Split a batch by full shard-key range.
     fn split_batch_by_key(
         &self,
         batch: &RecordBatch,
         split_point: &[u8],
     ) -> Result<(RecordBatch, RecordBatch)> {
-        use arrow_array::cast::AsArray;
-        use arrow_array::types::Int64Type;
-
-        // Extract timestamp column (our shard key is based on time)
-        let ts_column = batch
-            .column_by_name("timestamp")
-            .ok_or_else(|| Error::InvalidSchema("Missing timestamp column".into()))?;
-
-        let ts_array = ts_column
-            .as_primitive_opt::<Int64Type>()
-            .ok_or_else(|| Error::InvalidSchema("Timestamp not Int64".into()))?;
-
-        // Build selection indices
         let mut indices_a = Vec::new();
         let mut indices_b = Vec::new();
 
-        // Convert split point to timestamp
-        let split_ts = i64::from_be_bytes(
-            split_point
-                .try_into()
-                .map_err(|_| Error::Internal("Invalid split point".to_string()))?,
-        );
-
         for i in 0..batch.num_rows() {
-            let ts = ts_array.value(i);
-            if ts < split_ts {
+            let key_bytes = self.shard_key_for_row(batch, i)?.to_bytes();
+            if key_bytes.as_slice() < split_point {
                 indices_a.push(i as u32);
             } else {
                 indices_b.push(i as u32);
@@ -497,43 +400,6 @@ impl Ingester {
         let batch_b = arrow::compute::take_record_batch(batch, &indices_b_array)?;
 
         Ok((batch_a, batch_b))
-    }
-
-    /// Compute shard ID for a batch based on tenant and metric
-    fn compute_shard_id(&self, batch: &RecordBatch) -> String {
-        // Extract metric name if available for shard key computation
-        let metric_name = if let Some(col) = batch.column_by_name("metric_name") {
-            use arrow_array::cast::AsArray;
-            if let Some(arr) = col.as_string_opt::<i32>() {
-                arr.value(0).to_string()
-            } else {
-                "unknown".to_string()
-            }
-        } else {
-            "unknown".to_string()
-        };
-
-        // Extract timestamp for time-based sharding
-        let timestamp = if let Some(col) = batch.column_by_name("timestamp") {
-            use arrow_array::cast::AsArray;
-            if let Some(arr) = col.as_primitive_opt::<arrow_array::types::TimestampNanosecondType>()
-            {
-                arr.value(0)
-            } else if let Some(arr) = col.as_primitive_opt::<arrow_array::types::Int64Type>() {
-                arr.value(0)
-            } else {
-                self.clock.now_nanos()
-            }
-        } else {
-            self.clock.now_nanos()
-        };
-
-        // Create shard key and convert to shard ID
-        let shard_key = ShardKey::new(self.default_tenant_id, &metric_name, timestamp);
-        format!(
-            "shard-{:x}",
-            u64::from_be_bytes(shard_key.to_bytes()[0..8].try_into().unwrap_or([0u8; 8]))
-        )
     }
 
     /// Extract all unique metric names from a batch for topic routing
@@ -582,32 +448,204 @@ impl Ingester {
             || buffer.size_bytes() >= self.config.flush_size_bytes
     }
 
-    /// Append a batch, flushing existing buffered data first when schemas differ.
-    ///
-    /// This prevents heterogeneous RecordBatch concatenation failures during flush.
-    async fn append_to_buffer_and_maybe_flush(
+    async fn total_buffer_rows(&self) -> usize {
+        self.buffers
+            .read()
+            .await
+            .values()
+            .map(WriteBuffer::row_count)
+            .sum()
+    }
+
+    async fn partition_batch_by_shard(
         &self,
+        batch: &RecordBatch,
+    ) -> Result<HashMap<String, RecordBatch>> {
+        let mut known_shards = self.metadata.list_shards().await?;
+        let mut row_indices: HashMap<String, Vec<u32>> = HashMap::new();
+
+        for row_idx in 0..batch.num_rows() {
+            let shard_key = self.shard_key_for_row(batch, row_idx)?;
+            let shard_id = self
+                .resolve_shard_id_for_key(&shard_key, &mut known_shards)
+                .await?;
+            row_indices
+                .entry(shard_id)
+                .or_default()
+                .push(row_idx as u32);
+        }
+
+        let mut shard_batches = HashMap::with_capacity(row_indices.len());
+        for (shard_id, indices) in row_indices {
+            let taken = arrow::array::UInt32Array::from(indices);
+            let shard_batch = arrow::compute::take_record_batch(batch, &taken)?;
+            shard_batches.insert(shard_id, shard_batch);
+        }
+
+        Ok(shard_batches)
+    }
+
+    fn shard_key_for_row(&self, batch: &RecordBatch, row_idx: usize) -> Result<ShardKey> {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::{Int64Type, TimestampNanosecondType};
+        use arrow_array::Array;
+
+        let timestamp_col = batch
+            .column_by_name("timestamp")
+            .ok_or_else(|| Error::InvalidSchema("Missing timestamp column".into()))?;
+        let timestamp =
+            if let Some(ts_array) = timestamp_col.as_primitive_opt::<TimestampNanosecondType>() {
+                if ts_array.is_null(row_idx) {
+                    return Err(Error::InvalidSchema("Null timestamp value".into()));
+                }
+                ts_array.value(row_idx)
+            } else if let Some(ts_array) = timestamp_col.as_primitive_opt::<Int64Type>() {
+                if ts_array.is_null(row_idx) {
+                    return Err(Error::InvalidSchema("Null timestamp value".into()));
+                }
+                ts_array.value(row_idx)
+            } else {
+                return Err(Error::InvalidSchema(format!(
+                    "Timestamp column must be Timestamp(Nanosecond) or Int64, got {:?}",
+                    timestamp_col.data_type()
+                )));
+            };
+
+        let metric_name = batch
+            .column_by_name("metric_name")
+            .and_then(|column| column.as_string_opt::<i32>())
+            .map(|column| {
+                if column.is_null(row_idx) {
+                    "unknown".to_string()
+                } else {
+                    column.value(row_idx).to_string()
+                }
+            })
+            .unwrap_or_else(|| "unknown".to_string());
+
+        Ok(ShardKey::new(
+            self.default_tenant_id,
+            &metric_name,
+            timestamp,
+        ))
+    }
+
+    async fn resolve_shard_id_for_key(
+        &self,
+        key: &ShardKey,
+        known_shards: &mut Vec<ShardMetadata>,
+    ) -> Result<String> {
+        let key_bytes = key.to_bytes();
+
+        if let Some(shard) = known_shards.iter().find(|shard| {
+            matches!(shard.state, ShardState::Splitting { .. })
+                && key_in_range(&key_bytes, &shard.key_range)
+        }) {
+            return Ok(shard.shard_id.clone());
+        }
+
+        if let Some(shard) = known_shards.iter().find(|shard| {
+            matches!(shard.state, ShardState::Active) && key_in_range(&key_bytes, &shard.key_range)
+        }) {
+            return Ok(shard.shard_id.clone());
+        }
+
+        if let Some(shard) = known_shards.iter().find(|shard| {
+            !matches!(shard.state, ShardState::PendingDeletion { .. })
+                && key_in_range(&key_bytes, &shard.key_range)
+        }) {
+            return Ok(shard.shard_id.clone());
+        }
+
+        let shard = self.ensure_shard_metadata(key).await?;
+        known_shards.push(shard.clone());
+        Ok(shard.shard_id)
+    }
+
+    async fn ensure_shard_metadata(&self, key: &ShardKey) -> Result<ShardMetadata> {
+        let shard_id = key.shard_id();
+        if let Some(existing) = self.metadata.get_shard_metadata(&shard_id).await? {
+            return Ok(existing);
+        }
+
+        let key_bytes = key.to_bytes();
+        let range_end = next_key_bytes(&key_bytes).ok_or_else(|| {
+            Error::Internal("Cannot derive shard end key from maximum key".to_string())
+        })?;
+        let metadata = ShardMetadata {
+            shard_id: shard_id.clone(),
+            generation: 0,
+            key_range: (key_bytes, range_end),
+            replicas: Vec::new(),
+            state: ShardState::Active,
+            min_time: key.time_bucket.start,
+            max_time: key.time_bucket.start + key.time_bucket.duration.as_nanos() as i64,
+        };
+
+        match self
+            .metadata
+            .update_shard_metadata(&shard_id, &metadata, 0)
+            .await
+        {
+            Ok(()) => self
+                .metadata
+                .get_shard_metadata(&shard_id)
+                .await?
+                .ok_or_else(|| {
+                    Error::Internal(format!(
+                        "Shard metadata for {} disappeared after creation",
+                        shard_id
+                    ))
+                }),
+            Err(Error::StaleGeneration { .. }) => self
+                .metadata
+                .get_shard_metadata(&shard_id)
+                .await?
+                .ok_or_else(|| {
+                    Error::Internal(format!(
+                        "Shard metadata for {} missing after concurrent creation",
+                        shard_id
+                    ))
+                }),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn append_batch_to_shard_buffers(&self, batch: RecordBatch) -> Result<()> {
+        let shard_batches = self.partition_batch_by_shard(&batch).await?;
+        for (shard_id, shard_batch) in shard_batches {
+            self.append_batch_to_specific_shard(&shard_id, shard_batch)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Append a batch to a shard-local buffer, flushing existing data first when schemas differ.
+    async fn append_batch_to_specific_shard(
+        &self,
+        shard_id: &str,
         batch: RecordBatch,
-        batch_size: usize,
     ) -> Result<()> {
+        let batch_size = batch.get_array_memory_size();
         let mut pending_batch = Some(batch);
 
         loop {
-            let mut buffer = self.buffer.write().await;
+            let mut buffers = self.buffers.write().await;
+            let total_size: usize = buffers.values().map(WriteBuffer::size_bytes).sum();
+            let buffer = buffers.entry(shard_id.to_string()).or_default();
 
             let incoming = pending_batch
                 .as_ref()
                 .ok_or_else(|| Error::Internal("Missing pending batch".to_string()))?;
 
-            // If schemas differ, flush current buffer before appending.
             if !buffer.schema_compatible(incoming) {
                 let existing = buffer.take();
-                drop(buffer);
-                self.flush_batches(existing).await?;
+                drop(buffers);
+                self.flush_shard_batches(shard_id, existing).await?;
                 continue;
             }
 
-            if buffer.size_bytes() + batch_size > self.config.max_buffer_size_bytes {
+            if total_size + batch_size > self.config.max_buffer_size_bytes {
                 telemetry::record_buffer_fullness_ratio(1.0);
                 return Err(Error::BufferFull);
             }
@@ -616,26 +654,29 @@ impl Ingester {
                 .take()
                 .ok_or_else(|| Error::Internal("Missing pending batch".to_string()))?;
             buffer.append(incoming)?;
-            let max_buffer_size = self.config.max_buffer_size_bytes.max(1) as f64;
-            telemetry::record_buffer_fullness_ratio(buffer.size_bytes() as f64 / max_buffer_size);
 
-            if self.should_flush(&buffer) {
+            let max_buffer_size = self.config.max_buffer_size_bytes.max(1) as f64;
+            let fullness = (total_size + batch_size) as f64 / max_buffer_size;
+            telemetry::record_buffer_fullness_ratio(fullness);
+
+            if self.should_flush(buffer) {
                 let batches = buffer.take();
-                drop(buffer);
-                self.flush_batches(batches).await?;
+                drop(buffers);
+                self.flush_shard_batches(shard_id, batches).await?;
             }
 
             return Ok(());
         }
     }
 
-    /// Flush batches to object storage
-    async fn flush_batches(&self, batches: Vec<RecordBatch>) -> Result<()> {
+    /// Flush a shard-local set of batches to object storage.
+    async fn flush_shard_batches(&self, shard_id: &str, batches: Vec<RecordBatch>) -> Result<()> {
         if batches.is_empty() {
             return Ok(());
         }
 
         info!(
+            shard_id,
             batch_count = batches.len(),
             total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>(),
             "Flushing batches to object storage"
@@ -649,7 +690,7 @@ impl Ingester {
         let parquet_size = parquet_bytes.len() as u64;
 
         // Generate path
-        let path = self.generate_path();
+        let path = self.generate_path(shard_id);
         debug!(path = %path, size_bytes = parquet_size, "Writing Parquet file");
 
         // Upload to object storage
@@ -664,6 +705,7 @@ impl Ingester {
             max_timestamp: self.extract_max_timestamp(&combined)?,
             row_count: combined.num_rows() as u64,
             size_bytes: parquet_size,
+            shard_id: Some(shard_id.to_string()),
         };
         self.metadata.register_chunk(&path, &chunk_metadata).await?;
 
@@ -673,12 +715,11 @@ impl Ingester {
         }
 
         // Broadcast to topic-aware streaming query subscribers
-        let shard_id = self.compute_shard_id(&combined);
         let metrics = self.extract_metrics(&combined);
         let topic_batch = TopicBatch {
             batch: combined,
             metadata: BatchMetadata {
-                shard_id,
+                shard_id: shard_id.to_string(),
                 tenant_id: self.default_tenant_id,
                 metrics,
             },
@@ -690,20 +731,23 @@ impl Ingester {
         // Truncate WAL after successful flush
         let flushed_up_to = self.last_wal_seq.load(Ordering::Acquire);
         if flushed_up_to > 0 {
-            if let Some(wal) = self.wal.as_ref() {
-                if let Err(e) = wal.lock().await.truncate_before(flushed_up_to).await {
-                    telemetry::record_wal_operation("truncate", "error");
-                    return Err(e);
+            let remaining_rows = self.total_buffer_rows().await;
+            if remaining_rows == 0 {
+                if let Some(wal) = self.wal.as_ref() {
+                    if let Err(e) = wal.lock().await.truncate_before(flushed_up_to).await {
+                        telemetry::record_wal_operation("truncate", "error");
+                        return Err(e);
+                    }
+                    telemetry::record_wal_operation("truncate", "ok");
                 }
-                telemetry::record_wal_operation("truncate", "ok");
-            }
-            self.last_flushed_seq
-                .store(flushed_up_to, Ordering::Release);
-            if let Err(e) = persist_flushed_seq(&self.config.wal.wal_dir, flushed_up_to) {
-                telemetry::record_wal_operation("persist_flushed_seq", "error");
-                warn!(error = %e, "Failed to persist flushed WAL sequence number");
-            } else {
-                telemetry::record_wal_operation("persist_flushed_seq", "ok");
+                self.last_flushed_seq
+                    .store(flushed_up_to, Ordering::Release);
+                if let Err(e) = persist_flushed_seq(&self.config.wal.wal_dir, flushed_up_to) {
+                    telemetry::record_wal_operation("persist_flushed_seq", "error");
+                    warn!(error = %e, "Failed to persist flushed WAL sequence number");
+                } else {
+                    telemetry::record_wal_operation("persist_flushed_seq", "ok");
+                }
             }
         }
 
@@ -722,31 +766,42 @@ impl Ingester {
             tokio::select! {
                 _ = interval.tick() => {
                     let should_flush = {
-                        let buffer = self.buffer.read().await;
+                        let buffers = self.buffers.read().await;
                         let last_flush = self.last_flush.read().await;
-                        !buffer.is_empty() && last_flush.elapsed() >= self.config.flush_interval
+                        buffers.values().any(|buffer| !buffer.is_empty())
+                            && last_flush.elapsed() >= self.config.flush_interval
                     };
 
                     if should_flush {
-                        let batches = {
-                            let mut buffer = self.buffer.write().await;
-                            buffer.take()
+                        let drained = {
+                            let mut buffers = self.buffers.write().await;
+                            buffers
+                                .iter_mut()
+                                .map(|(shard_id, buffer)| (shard_id.clone(), buffer.take()))
+                                .filter(|(_, batches)| !batches.is_empty())
+                                .collect::<Vec<_>>()
                         };
 
-                        if let Err(e) = self.flush_batches(batches).await {
-                            error!("Flush timer failed: {}", e);
+                        for (shard_id, batches) in drained {
+                            if let Err(e) = self.flush_shard_batches(&shard_id, batches).await {
+                                error!("Flush timer failed for shard {}: {}", shard_id, e);
+                            }
                         }
                     }
                 }
                 _ = self.shutdown.cancelled() => {
                     info!("Flush timer shutting down, flushing remaining data");
-                    let batches = {
-                        let mut buffer = self.buffer.write().await;
-                        buffer.take()
+                    let drained = {
+                        let mut buffers = self.buffers.write().await;
+                        buffers
+                            .iter_mut()
+                            .map(|(shard_id, buffer)| (shard_id.clone(), buffer.take()))
+                            .filter(|(_, batches)| !batches.is_empty())
+                            .collect::<Vec<_>>()
                     };
-                    if !batches.is_empty() {
-                        if let Err(e) = self.flush_batches(batches).await {
-                            error!("Final flush failed during shutdown: {}", e);
+                    for (shard_id, batches) in drained {
+                        if let Err(e) = self.flush_shard_batches(&shard_id, batches).await {
+                            error!("Final flush failed during shutdown for shard {}: {}", shard_id, e);
                         }
                     }
                     break;
@@ -756,13 +811,14 @@ impl Ingester {
     }
 
     /// Generate a unique path for the Parquet file
-    fn generate_path(&self) -> String {
+    fn generate_path(&self, shard_id: &str) -> String {
         let now = self.clock.now();
         let uuid = uuid::Uuid::new_v4();
 
         format!(
-            "{}/data/year={}/month={:02}/day={:02}/hour={:02}/chunk_{}.parquet",
+            "{}/data/shard={}/year={}/month={:02}/day={:02}/hour={:02}/chunk_{}.parquet",
             self.storage_config.tenant_id,
+            shard_id,
             now.format("%Y"),
             now.format("%m"),
             now.format("%d"),
@@ -822,11 +878,11 @@ impl Ingester {
 
     /// Get current buffer stats
     pub async fn buffer_stats(&self) -> BufferStats {
-        let buffer = self.buffer.read().await;
+        let buffers = self.buffers.read().await;
         BufferStats {
-            row_count: buffer.row_count(),
-            size_bytes: buffer.size_bytes(),
-            batch_count: buffer.batch_count(),
+            row_count: buffers.values().map(WriteBuffer::row_count).sum(),
+            size_bytes: buffers.values().map(WriteBuffer::size_bytes).sum(),
+            batch_count: buffers.values().map(WriteBuffer::batch_count).sum(),
         }
     }
 }
@@ -839,6 +895,8 @@ pub struct ChunkMetadata {
     pub max_timestamp: i64,
     pub row_count: u64,
     pub size_bytes: u64,
+    #[serde(default)]
+    pub shard_id: Option<String>,
 }
 
 /// Buffer statistics

--- a/src/metadata/client.rs
+++ b/src/metadata/client.rs
@@ -137,9 +137,7 @@ pub trait MetadataClient: Send + Sync {
     ) -> Result<()>;
 
     /// List all known shard metadata entries.
-    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
-        Ok(Vec::new())
-    }
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>>;
 
     // Compaction lease methods for mutual exclusion
 

--- a/src/metadata/client.rs
+++ b/src/metadata/client.rs
@@ -43,38 +43,17 @@ pub trait MetadataClient: Send + Sync {
         &self,
         range: TimeRange,
         _predicates: &[super::predicates::ColumnPredicate],
-    ) -> Result<Vec<TimeIndexEntry>> {
-        // Default implementation: fallback to time-only filtering
-        // (for backwards compatibility with LocalMetadataClient)
-        self.get_chunks(range).await
-    }
+    ) -> Result<Vec<TimeIndexEntry>>;
 
     /// Get chunks for a time range/predicate set with an optional shard filter.
     ///
-    /// Implementations may use the shard filter to reduce the amount of metadata scanned.
-    /// The default implementation preserves correctness for legacy data by keeping chunks
-    /// that do not yet carry explicit shard identity.
+    /// Implementations should use the shard filter to reduce the amount of metadata scanned.
     async fn get_chunks_with_predicates_for_shards(
         &self,
         range: TimeRange,
         predicates: &[super::predicates::ColumnPredicate],
         shard_ids: &[String],
-    ) -> Result<Vec<TimeIndexEntry>> {
-        let chunks = self.get_chunks_with_predicates(range, predicates).await?;
-        if shard_ids.is_empty() {
-            return Ok(chunks);
-        }
-
-        let wanted: std::collections::HashSet<&str> =
-            shard_ids.iter().map(String::as_str).collect();
-        Ok(chunks
-            .into_iter()
-            .filter(|entry| match entry.shard_id.as_deref() {
-                Some(shard_id) => wanted.contains(shard_id),
-                None => true,
-            })
-            .collect())
-    }
+    ) -> Result<Vec<TimeIndexEntry>>;
 
     /// Get chunk metadata by path
     async fn get_chunk(&self, path: &str) -> Result<Option<ChunkMetadata>>;

--- a/src/metadata/client.rs
+++ b/src/metadata/client.rs
@@ -49,6 +49,33 @@ pub trait MetadataClient: Send + Sync {
         self.get_chunks(range).await
     }
 
+    /// Get chunks for a time range/predicate set with an optional shard filter.
+    ///
+    /// Implementations may use the shard filter to reduce the amount of metadata scanned.
+    /// The default implementation preserves correctness for legacy data by keeping chunks
+    /// that do not yet carry explicit shard identity.
+    async fn get_chunks_with_predicates_for_shards(
+        &self,
+        range: TimeRange,
+        predicates: &[super::predicates::ColumnPredicate],
+        shard_ids: &[String],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        let chunks = self.get_chunks_with_predicates(range, predicates).await?;
+        if shard_ids.is_empty() {
+            return Ok(chunks);
+        }
+
+        let wanted: std::collections::HashSet<&str> =
+            shard_ids.iter().map(String::as_str).collect();
+        Ok(chunks
+            .into_iter()
+            .filter(|entry| match entry.shard_id.as_deref() {
+                Some(shard_id) => wanted.contains(shard_id),
+                None => true,
+            })
+            .collect())
+    }
+
     /// Get chunk metadata by path
     async fn get_chunk(&self, path: &str) -> Result<Option<ChunkMetadata>>;
 
@@ -129,6 +156,11 @@ pub trait MetadataClient: Send + Sync {
         metadata: &crate::sharding::ShardMetadata,
         expected_generation: u64,
     ) -> Result<()>;
+
+    /// List all known shard metadata entries.
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
+        Ok(Vec::new())
+    }
 
     // Compaction lease methods for mutual exclusion
 

--- a/src/metadata/local.rs
+++ b/src/metadata/local.rs
@@ -71,6 +71,13 @@ impl Default for LocalMetadataClient {
 #[async_trait]
 impl MetadataClient for LocalMetadataClient {
     async fn register_chunk(&self, path: &str, metadata: &ChunkMetadata) -> Result<()> {
+        if metadata.shard_id.is_empty() {
+            return Err(crate::Error::Metadata(format!(
+                "chunk {} is missing shard_id",
+                path
+            )));
+        }
+
         // Store chunk metadata
         self.chunks.insert(path.to_string(), metadata.clone());
 
@@ -94,6 +101,14 @@ impl MetadataClient for LocalMetadataClient {
     }
 
     async fn get_chunks(&self, range: TimeRange) -> Result<Vec<TimeIndexEntry>> {
+        self.get_chunks_with_predicates(range, &[]).await
+    }
+
+    async fn get_chunks_with_predicates(
+        &self,
+        range: TimeRange,
+        _predicates: &[super::predicates::ColumnPredicate],
+    ) -> Result<Vec<TimeIndexEntry>> {
         let mut results = Vec::new();
         let mut seen = std::collections::HashSet::new();
 
@@ -127,6 +142,25 @@ impl MetadataClient for LocalMetadataClient {
         results.sort_by_key(|e| e.min_timestamp);
 
         Ok(results)
+    }
+
+    async fn get_chunks_with_predicates_for_shards(
+        &self,
+        range: TimeRange,
+        predicates: &[super::predicates::ColumnPredicate],
+        shard_ids: &[String],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        let chunks = self.get_chunks_with_predicates(range, predicates).await?;
+        if shard_ids.is_empty() {
+            return Ok(chunks);
+        }
+
+        let wanted: std::collections::HashSet<&str> =
+            shard_ids.iter().map(String::as_str).collect();
+        Ok(chunks
+            .into_iter()
+            .filter(|entry| wanted.contains(entry.shard_id.as_str()))
+            .collect())
     }
 
     async fn get_chunk(&self, path: &str) -> Result<Option<ChunkMetadata>> {
@@ -343,10 +377,7 @@ impl MetadataClient for LocalMetadataClient {
         let results: Vec<TimeIndexEntry> = self
             .chunks
             .iter()
-            .filter(|entry| match entry.value().shard_id.as_deref() {
-                Some(chunk_shard) => chunk_shard == shard_id,
-                None => entry.key().contains(shard_id),
-            })
+            .filter(|entry| entry.value().shard_id == shard_id)
             .map(|entry| TimeIndexEntry::from(entry.value()))
             .collect();
 
@@ -521,7 +552,7 @@ mod tests {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         }
     }
 

--- a/src/metadata/local.rs
+++ b/src/metadata/local.rs
@@ -340,12 +340,13 @@ impl MetadataClient for LocalMetadataClient {
     }
 
     async fn get_chunks_for_shard(&self, shard_id: &str) -> Result<Vec<TimeIndexEntry>> {
-        // In a real implementation, we'd have shard-to-chunk mappings
-        // For now, filter chunks by path pattern
         let results: Vec<TimeIndexEntry> = self
             .chunks
             .iter()
-            .filter(|entry| entry.key().contains(shard_id))
+            .filter(|entry| match entry.value().shard_id.as_deref() {
+                Some(chunk_shard) => chunk_shard == shard_id,
+                None => entry.key().contains(shard_id),
+            })
             .map(|entry| TimeIndexEntry::from(entry.value()))
             .collect();
 
@@ -384,6 +385,14 @@ impl MetadataClient for LocalMetadataClient {
             .insert(shard_id.to_string(), new_metadata);
 
         Ok(())
+    }
+
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
+        Ok(self
+            .shard_metadata
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect())
     }
 
     async fn acquire_lease(
@@ -512,6 +521,7 @@ mod tests {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         }
     }
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -54,7 +54,7 @@ pub struct TimeIndexEntry {
     pub max_timestamp: i64,
     pub row_count: u64,
     pub size_bytes: u64,
-    pub shard_id: Option<String>,
+    pub shard_id: String,
 }
 
 impl From<&ChunkMetadata> for TimeIndexEntry {

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -54,6 +54,7 @@ pub struct TimeIndexEntry {
     pub max_timestamp: i64,
     pub row_count: u64,
     pub size_bytes: u64,
+    pub shard_id: Option<String>,
 }
 
 impl From<&ChunkMetadata> for TimeIndexEntry {
@@ -64,6 +65,7 @@ impl From<&ChunkMetadata> for TimeIndexEntry {
             max_timestamp: meta.max_timestamp,
             row_count: meta.row_count,
             size_bytes: meta.size_bytes,
+            shard_id: meta.shard_id.clone(),
         }
     }
 }

--- a/src/metadata/s3.rs
+++ b/src/metadata/s3.rs
@@ -817,7 +817,7 @@ impl ObjectStoreMetadataClient {
             column_stats: HashMap::new(),
             level: 0, // New chunks start at L0
             version: String::new(),
-            shard_id: None,
+            shard_id: metadata.shard_id.clone(),
         };
 
         let catalog = cas_retry!({
@@ -1135,6 +1135,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                                 max_timestamp: extended.base.max_timestamp,
                                 row_count: extended.base.row_count,
                                 size_bytes: extended.base.size_bytes,
+                                shard_id: extended.shard_id.clone(),
                             });
                         } else {
                             pruned_count += 1;
@@ -1200,6 +1201,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                 max_timestamp: extended.base.max_timestamp,
                 row_count: extended.base.row_count,
                 size_bytes: extended.base.size_bytes,
+                shard_id: extended.shard_id.clone(),
             })
             .collect();
 
@@ -1556,6 +1558,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                 max_timestamp: extended.base.max_timestamp,
                 row_count: extended.base.row_count,
                 size_bytes: extended.base.size_bytes,
+                shard_id: extended.shard_id.clone(),
             })
             .collect();
 
@@ -1618,6 +1621,29 @@ impl MetadataClient for ObjectStoreMetadataClient {
             );
             Ok(())
         })
+    }
+
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
+        use futures::StreamExt;
+
+        let prefix = Path::from_iter([&self.config.metadata_prefix, "shards/"]);
+        let mut stream = self.object_store.list(Some(&prefix));
+        let mut shards = Vec::new();
+
+        while let Some(entry) = stream.next().await {
+            let meta = entry?;
+            if !meta.location.as_ref().ends_with(".json") {
+                continue;
+            }
+
+            let result = self.object_store.get(&meta.location).await?;
+            let bytes = result.bytes().await?;
+            let shard: crate::sharding::ShardMetadata = serde_json::from_slice(&bytes)
+                .map_err(|e| Error::Metadata(format!("Corrupt shard metadata: {}", e)))?;
+            shards.push(shard);
+        }
+
+        Ok(shards)
     }
 
     async fn acquire_lease(

--- a/src/metadata/s3.rs
+++ b/src/metadata/s3.rs
@@ -96,9 +96,6 @@ pub struct ChunkMetadataExtended {
     /// Version/ETag for atomic operations
     #[serde(default, skip_serializing)]
     pub version: String,
-    /// Shard ID this chunk belongs to (None for legacy data)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub shard_id: Option<String>,
 }
 
 /// Unified metadata catalog -- single S3 object, single ETag
@@ -817,7 +814,6 @@ impl ObjectStoreMetadataClient {
             column_stats: HashMap::new(),
             level: 0, // New chunks start at L0
             version: String::new(),
-            shard_id: metadata.shard_id.clone(),
         };
 
         let catalog = cas_retry!({
@@ -1085,6 +1081,13 @@ impl ObjectStoreMetadataClient {
 #[async_trait]
 impl MetadataClient for ObjectStoreMetadataClient {
     async fn register_chunk(&self, path: &str, metadata: &ChunkMetadata) -> Result<()> {
+        if metadata.shard_id.is_empty() {
+            return Err(Error::Metadata(format!(
+                "chunk {} is missing shard_id",
+                path
+            )));
+        }
+
         // Use atomic registration with retry logic
         self.atomic_register_chunk(path, metadata).await
     }
@@ -1135,7 +1138,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                                 max_timestamp: extended.base.max_timestamp,
                                 row_count: extended.base.row_count,
                                 size_bytes: extended.base.size_bytes,
-                                shard_id: extended.shard_id.clone(),
+                                shard_id: extended.base.shard_id.clone(),
                             });
                         } else {
                             pruned_count += 1;
@@ -1164,6 +1167,74 @@ impl MetadataClient for ObjectStoreMetadataClient {
             .chunks
             .get(path)
             .map(|extended| extended.base.clone()))
+    }
+
+    async fn get_chunks_with_predicates_for_shards(
+        &self,
+        range: TimeRange,
+        predicates: &[super::predicates::ColumnPredicate],
+        shard_ids: &[String],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        if shard_ids.is_empty() {
+            return self.get_chunks_with_predicates(range, predicates).await;
+        }
+
+        let wanted: std::collections::HashSet<&str> =
+            shard_ids.iter().map(String::as_str).collect();
+        let catalog = self.load_catalog_cached().await?;
+
+        let bucket_size = self.nanos_per_bucket()?;
+        let start_bucket = Self::hour_bucket(range.start, bucket_size);
+        let end_bucket = Self::hour_bucket(range.end, bucket_size);
+
+        let mut results = Vec::new();
+        let mut pruned_count = 0;
+        let mut seen = std::collections::HashSet::new();
+
+        for (_bucket, paths) in catalog.time_index.range(start_bucket..=end_bucket) {
+            for path in paths {
+                if seen.contains(path) {
+                    continue;
+                }
+                seen.insert(path.clone());
+
+                if let Some(extended) = catalog.chunks.get(path) {
+                    if !wanted.contains(extended.base.shard_id.as_str()) {
+                        continue;
+                    }
+
+                    let chunk_range =
+                        TimeRange::new(extended.base.min_timestamp, extended.base.max_timestamp);
+                    if chunk_range.overlaps(&range) {
+                        let satisfies_predicates = predicates
+                            .iter()
+                            .all(|pred| pred.evaluate_against_stats(&extended.column_stats));
+
+                        if satisfies_predicates {
+                            results.push(TimeIndexEntry {
+                                chunk_path: path.clone(),
+                                min_timestamp: extended.base.min_timestamp,
+                                max_timestamp: extended.base.max_timestamp,
+                                row_count: extended.base.row_count,
+                                size_bytes: extended.base.size_bytes,
+                                shard_id: extended.base.shard_id.clone(),
+                            });
+                        } else {
+                            pruned_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        results.sort_by_key(|entry| entry.min_timestamp);
+        debug!(
+            "get_chunks_with_predicates_for_shards returned {} chunks for {} shards ({} pruned by column predicates)",
+            results.len(),
+            shard_ids.len(),
+            pruned_count
+        );
+        Ok(results)
     }
 
     async fn delete_chunk(&self, path: &str) -> Result<()> {
@@ -1201,7 +1272,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                 max_timestamp: extended.base.max_timestamp,
                 row_count: extended.base.row_count,
                 size_bytes: extended.base.size_bytes,
-                shard_id: extended.shard_id.clone(),
+                shard_id: extended.base.shard_id.clone(),
             })
             .collect();
 
@@ -1540,25 +1611,17 @@ impl MetadataClient for ObjectStoreMetadataClient {
     async fn get_chunks_for_shard(&self, shard_id: &str) -> Result<Vec<TimeIndexEntry>> {
         let catalog = self.load_catalog_cached().await?;
 
-        // Filter chunks by shard_id field first, fall back to path.contains() for legacy data
         let results: Vec<TimeIndexEntry> = catalog
             .chunks
             .iter()
-            .filter(|(path, extended)| {
-                if let Some(ref chunk_shard) = extended.shard_id {
-                    chunk_shard == shard_id
-                } else {
-                    // Legacy fallback: match by path substring
-                    path.contains(shard_id)
-                }
-            })
+            .filter(|(_, extended)| extended.base.shard_id == shard_id)
             .map(|(path, extended)| TimeIndexEntry {
                 chunk_path: path.clone(),
                 min_timestamp: extended.base.min_timestamp,
                 max_timestamp: extended.base.max_timestamp,
                 row_count: extended.base.row_count,
                 size_bytes: extended.base.size_bytes,
-                shard_id: extended.shard_id.clone(),
+                shard_id: extended.base.shard_id.clone(),
             })
             .collect();
 

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -9,6 +9,7 @@ mod cache;
 mod cached_store;
 mod dedup;
 mod engine;
+mod planner;
 mod router;
 mod streaming;
 mod telemetry;
@@ -183,10 +184,22 @@ impl QueryNode {
                 (Err(e), _) | (_, Err(e)) => return Err(e),
             };
 
+            let shard_ids = if let Some(metric_names) = planner::exact_metric_names(&predicates) {
+                let shards = self.metadata.list_shards().await?;
+                planner::shard_ids_for_metrics(
+                    planner::tenant_id_for_sharding(tenant_id),
+                    time_range,
+                    &metric_names,
+                    &shards,
+                )
+            } else {
+                Vec::new()
+            };
+
             // Get relevant chunks from metadata with predicate pushdown
             let chunks = self
                 .metadata
-                .get_chunks_with_predicates(time_range, &predicates)
+                .get_chunks_with_predicates_for_shards(time_range, &predicates, &shard_ids)
                 .await?;
             let bytes_scanned = chunks.iter().map(|chunk| chunk.size_bytes).sum::<u64>();
 

--- a/src/query/planner.rs
+++ b/src/query/planner.rs
@@ -1,0 +1,226 @@
+use std::collections::BTreeSet;
+
+use crate::metadata::predicates::{ColumnPredicate, PredicateValue};
+use crate::metadata::TimeRange;
+use crate::sharding::{key_in_range, ShardKey, ShardMetadata, ShardState, TimeBucket};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MetricConstraint {
+    Unconstrained,
+    Exact(BTreeSet<String>),
+    Unknown,
+}
+
+pub(crate) fn tenant_id_for_sharding(tenant_id: &str) -> u32 {
+    tenant_id.parse().unwrap_or(0)
+}
+
+pub(crate) fn exact_metric_names(predicates: &[ColumnPredicate]) -> Option<BTreeSet<String>> {
+    let constraint = predicates
+        .iter()
+        .fold(MetricConstraint::Unconstrained, |acc, predicate| {
+            merge_and(acc, metric_constraint(predicate))
+        });
+
+    match constraint {
+        MetricConstraint::Exact(metrics) => Some(metrics),
+        MetricConstraint::Unconstrained | MetricConstraint::Unknown => None,
+    }
+}
+
+pub(crate) fn shard_ids_for_metrics(
+    tenant_id: u32,
+    time_range: TimeRange,
+    metric_names: &BTreeSet<String>,
+    shards: &[ShardMetadata],
+) -> Vec<String> {
+    if metric_names.is_empty() {
+        return Vec::new();
+    }
+
+    let bucket_starts = TimeBucket::bucket_starts_in_range(time_range.start, time_range.end);
+    if bucket_starts.is_empty() {
+        return Vec::new();
+    }
+
+    let mut shard_ids = BTreeSet::new();
+    for metric_name in metric_names {
+        let metric_hash = ShardKey::hash_metric_name(metric_name);
+        for bucket_start in &bucket_starts {
+            let key = ShardKey::from_metric_hash(tenant_id, metric_hash, *bucket_start);
+            let key_bytes = key.to_bytes();
+            for shard in shards {
+                if matches!(shard.state, ShardState::PendingDeletion { .. }) {
+                    continue;
+                }
+                if key_in_range(&key_bytes, &shard.key_range) {
+                    shard_ids.insert(shard.shard_id.clone());
+                }
+            }
+        }
+    }
+
+    shard_ids.into_iter().collect()
+}
+
+fn metric_constraint(predicate: &ColumnPredicate) -> MetricConstraint {
+    match predicate {
+        ColumnPredicate::Eq(column, PredicateValue::String(value)) if column == "metric_name" => {
+            MetricConstraint::Exact(BTreeSet::from([value.clone()]))
+        }
+        ColumnPredicate::In(column, values) if column == "metric_name" => values
+            .iter()
+            .map(|value| match value {
+                PredicateValue::String(value) => Some(value.clone()),
+                _ => None,
+            })
+            .collect::<Option<BTreeSet<_>>>()
+            .map(MetricConstraint::Exact)
+            .unwrap_or(MetricConstraint::Unknown),
+        ColumnPredicate::Eq(column, _)
+        | ColumnPredicate::NotEq(column, _)
+        | ColumnPredicate::Lt(column, _)
+        | ColumnPredicate::LtEq(column, _)
+        | ColumnPredicate::Gt(column, _)
+        | ColumnPredicate::GtEq(column, _)
+        | ColumnPredicate::In(column, _)
+        | ColumnPredicate::NotIn(column, _)
+        | ColumnPredicate::Between(column, _, _)
+            if column == "metric_name" =>
+        {
+            MetricConstraint::Unknown
+        }
+        ColumnPredicate::And(left, right) => {
+            merge_and(metric_constraint(left), metric_constraint(right))
+        }
+        ColumnPredicate::Or(left, right) => {
+            merge_or(metric_constraint(left), metric_constraint(right))
+        }
+        ColumnPredicate::Not(inner) => {
+            if mentions_metric_name(inner) {
+                MetricConstraint::Unknown
+            } else {
+                MetricConstraint::Unconstrained
+            }
+        }
+        _ => MetricConstraint::Unconstrained,
+    }
+}
+
+fn merge_and(left: MetricConstraint, right: MetricConstraint) -> MetricConstraint {
+    match (left, right) {
+        (MetricConstraint::Unknown, _) | (_, MetricConstraint::Unknown) => {
+            MetricConstraint::Unknown
+        }
+        (MetricConstraint::Unconstrained, other) | (other, MetricConstraint::Unconstrained) => {
+            other
+        }
+        (MetricConstraint::Exact(left), MetricConstraint::Exact(right)) => {
+            MetricConstraint::Exact(left.intersection(&right).cloned().collect())
+        }
+    }
+}
+
+fn merge_or(left: MetricConstraint, right: MetricConstraint) -> MetricConstraint {
+    match (left, right) {
+        (MetricConstraint::Exact(mut left), MetricConstraint::Exact(right)) => {
+            left.extend(right);
+            MetricConstraint::Exact(left)
+        }
+        (MetricConstraint::Unconstrained, MetricConstraint::Unconstrained) => {
+            MetricConstraint::Unconstrained
+        }
+        _ => MetricConstraint::Unknown,
+    }
+}
+
+fn mentions_metric_name(predicate: &ColumnPredicate) -> bool {
+    match predicate {
+        ColumnPredicate::Eq(column, _)
+        | ColumnPredicate::NotEq(column, _)
+        | ColumnPredicate::Lt(column, _)
+        | ColumnPredicate::LtEq(column, _)
+        | ColumnPredicate::Gt(column, _)
+        | ColumnPredicate::GtEq(column, _)
+        | ColumnPredicate::In(column, _)
+        | ColumnPredicate::NotIn(column, _)
+        | ColumnPredicate::Between(column, _, _) => column == "metric_name",
+        ColumnPredicate::And(left, right) | ColumnPredicate::Or(left, right) => {
+            mentions_metric_name(left) || mentions_metric_name(right)
+        }
+        ColumnPredicate::Not(inner) => mentions_metric_name(inner),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn metric_eq(value: &str) -> ColumnPredicate {
+        ColumnPredicate::Eq(
+            "metric_name".to_string(),
+            PredicateValue::String(value.to_string()),
+        )
+    }
+
+    fn service_eq(value: &str) -> ColumnPredicate {
+        ColumnPredicate::Eq(
+            "service".to_string(),
+            PredicateValue::String(value.to_string()),
+        )
+    }
+
+    fn shard_for(metric_name: &str, ts: i64) -> ShardMetadata {
+        let key = ShardKey::new(0, metric_name, ts);
+        let start = key.to_bytes();
+        let mut end = start.clone();
+        *end.last_mut().unwrap() += 1;
+        ShardMetadata {
+            shard_id: key.shard_id(),
+            generation: 1,
+            key_range: (start, end),
+            replicas: Vec::new(),
+            state: ShardState::Active,
+            min_time: ts,
+            max_time: ts + 300_000_000_000,
+        }
+    }
+
+    #[test]
+    fn exact_metric_names_intersects_and_constraints() {
+        let metrics = exact_metric_names(&[
+            ColumnPredicate::Or(Box::new(metric_eq("cpu")), Box::new(metric_eq("mem"))),
+            ColumnPredicate::Or(Box::new(metric_eq("cpu")), Box::new(metric_eq("disk"))),
+            service_eq("api"),
+        ])
+        .unwrap();
+
+        assert_eq!(metrics, BTreeSet::from(["cpu".to_string()]));
+    }
+
+    #[test]
+    fn exact_metric_names_rejects_mixed_metric_or_non_metric_or() {
+        let metrics = exact_metric_names(&[ColumnPredicate::Or(
+            Box::new(metric_eq("cpu")),
+            Box::new(service_eq("api")),
+        )]);
+
+        assert!(metrics.is_none());
+    }
+
+    #[test]
+    fn shard_ids_for_metrics_matches_full_shard_keys() {
+        let ts = 1_700_000_000_000_000_000i64;
+        let shards = vec![shard_for("cpu", ts), shard_for("mem", ts)];
+        let metrics = BTreeSet::from(["cpu".to_string()]);
+
+        let shard_ids = shard_ids_for_metrics(
+            0,
+            TimeRange::new(ts, ts + 60_000_000_000),
+            &metrics,
+            &shards,
+        );
+
+        assert_eq!(shard_ids, vec![shards[0].shard_id.clone()]);
+    }
+}

--- a/src/query/streaming.rs
+++ b/src/query/streaming.rs
@@ -1,6 +1,6 @@
 //! Streaming query support (historical + live)
 
-use super::QueryEngine;
+use super::{planner, QueryEngine};
 use crate::ingester::FilteredReceiver;
 use crate::metadata::predicates::{ColumnPredicate, PredicateValue};
 use crate::metadata::MetadataClient;
@@ -103,10 +103,17 @@ impl StreamingQueryExecutor {
         // Parse SQL to extract predicates for live filtering
         let query_filter = QueryFilter::from_sql(sql);
 
+        let shard_ids = if let Some(metric_names) = planner::exact_metric_names(&predicates) {
+            let shards = self.metadata.list_shards().await?;
+            planner::shard_ids_for_metrics(0, time_range, &metric_names, &shards)
+        } else {
+            Vec::new()
+        };
+
         // Get historical chunks with predicate pushdown
         let chunks = self
             .metadata
-            .get_chunks_with_predicates(time_range, &predicates)
+            .get_chunks_with_predicates_for_shards(time_range, &predicates, &shard_ids)
             .await?;
 
         let chunk_paths: Vec<String> = chunks

--- a/src/sharding/mod.rs
+++ b/src/sharding/mod.rs
@@ -43,6 +43,25 @@ impl TimeBucket {
         let nanos_per_5min = 5 * 60 * 1_000_000_000i64;
         (timestamp / nanos_per_5min) * nanos_per_5min
     }
+
+    /// Enumerate all 5-minute bucket starts overlapping a time range.
+    pub fn bucket_starts_in_range(start: i64, end: i64) -> Vec<i64> {
+        if end < start {
+            return Vec::new();
+        }
+
+        let mut buckets = Vec::new();
+        let mut current = Self::round_to_5min(start);
+        let last = Self::round_to_5min(end);
+        let step = 5 * 60 * 1_000_000_000i64;
+
+        while current <= last {
+            buckets.push(current);
+            current += step;
+        }
+
+        buckets
+    }
 }
 
 /// Shard key structure
@@ -56,15 +75,22 @@ pub struct ShardKey {
 impl ShardKey {
     /// Create a shard key from components
     pub fn new(tenant_id: u32, metric_name: &str, timestamp: i64) -> Self {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        metric_name.hash(&mut hasher);
-        let metric_hash = (hasher.finish() & 0xFFFF) as u16;
+        Self {
+            tenant_id,
+            metric_hash: Self::hash_metric_name(metric_name),
+            time_bucket: TimeBucket::five_minute(timestamp),
+        }
+    }
 
+    /// Create a shard key from pre-hashed metric metadata.
+    pub fn from_metric_hash(tenant_id: u32, metric_hash: u16, bucket_start: i64) -> Self {
         Self {
             tenant_id,
             metric_hash,
-            time_bucket: TimeBucket::five_minute(timestamp),
+            time_bucket: TimeBucket {
+                start: bucket_start,
+                duration: Duration::from_secs(300),
+            },
         }
     }
 
@@ -76,6 +102,102 @@ impl ShardKey {
         bytes.extend_from_slice(&self.time_bucket.start.to_be_bytes());
         bytes
     }
+
+    /// Convert to a stable shard identifier derived from the full shard key bytes.
+    pub fn shard_id(&self) -> ShardId {
+        format!("shard-{}", hex_encode(&self.to_bytes()))
+    }
+
+    /// Compute a stable 16-bit metric hash for shard routing.
+    pub fn hash_metric_name(metric_name: &str) -> u16 {
+        let mut hash = 0xcbf29ce484222325u64;
+        for byte in metric_name.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        (hash & 0xFFFF) as u16
+    }
+}
+
+/// Check whether a full shard key falls inside a shard range.
+pub fn key_in_range(key: &[u8], range: &(Vec<u8>, Vec<u8>)) -> bool {
+    key >= range.0.as_slice() && key < range.1.as_slice()
+}
+
+/// Return the next lexicographic key for a fixed-width big-endian byte sequence.
+pub fn next_key_bytes(bytes: &[u8]) -> Option<Vec<u8>> {
+    let mut next = bytes.to_vec();
+    for idx in (0..next.len()).rev() {
+        if next[idx] != u8::MAX {
+            next[idx] += 1;
+            for trailing in &mut next[idx + 1..] {
+                *trailing = 0;
+            }
+            return Some(next);
+        }
+    }
+    None
+}
+
+/// Compute the midpoint between two equally-sized lexicographic byte ranges.
+pub fn midpoint_bytes(start: &[u8], end: &[u8]) -> Option<Vec<u8>> {
+    if start.len() != end.len() || start >= end {
+        return None;
+    }
+
+    let mut delta = vec![0u8; start.len()];
+    let mut borrow = 0i16;
+    for idx in (0..start.len()).rev() {
+        let diff = i16::from(end[idx]) - i16::from(start[idx]) - borrow;
+        if diff < 0 {
+            delta[idx] = (diff + 256) as u8;
+            borrow = 1;
+        } else {
+            delta[idx] = diff as u8;
+            borrow = 0;
+        }
+    }
+
+    if delta.iter().all(|byte| *byte == 0) {
+        return None;
+    }
+
+    let mut half = delta.clone();
+    let mut remainder = 0u16;
+    for byte in &mut half {
+        let total = (remainder << 8) | u16::from(*byte);
+        *byte = (total / 2) as u8;
+        remainder = total % 2;
+    }
+
+    if half.iter().all(|byte| *byte == 0) {
+        return None;
+    }
+
+    let mut midpoint = start.to_vec();
+    let mut carry = 0u16;
+    for idx in (0..midpoint.len()).rev() {
+        let total = u16::from(midpoint[idx]) + u16::from(half[idx]) + carry;
+        midpoint[idx] = (total & 0xFF) as u8;
+        carry = total >> 8;
+    }
+
+    if carry > 0 || midpoint.as_slice() <= start || midpoint.as_slice() >= end {
+        return None;
+    }
+
+    Some(midpoint)
+}
+
+/// Encode bytes as lowercase hexadecimal without introducing an extra dependency.
+pub fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
 }
 
 /// Shard state

--- a/src/sharding/mod.rs
+++ b/src/sharding/mod.rs
@@ -13,7 +13,8 @@ pub use rebalancer::RebalanceStrategy;
 pub use router::ShardRouter;
 pub use splitter::{ShardSplitter, SplitPhase, SplitProgress};
 
-use std::time::Duration;
+use std::{hash::Hasher, time::Duration};
+use twox_hash::XxHash64;
 
 /// Shard identifier
 pub type ShardId = String;
@@ -110,12 +111,10 @@ impl ShardKey {
 
     /// Compute a stable 16-bit metric hash for shard routing.
     pub fn hash_metric_name(metric_name: &str) -> u16 {
-        let mut hash = 0xcbf29ce484222325u64;
-        for byte in metric_name.as_bytes() {
-            hash ^= u64::from(*byte);
-            hash = hash.wrapping_mul(0x100000001b3);
-        }
-        (hash & 0xFFFF) as u16
+        // Preserve the existing 16-bit routing space while using a standard xxHash64 implementation.
+        let mut hasher = XxHash64::with_seed(0);
+        hasher.write(metric_name.as_bytes());
+        (hasher.finish() & 0xFFFF) as u16
     }
 }
 
@@ -240,5 +239,24 @@ impl ShardMetadata {
     /// Check if the shard is active
     pub fn is_active(&self) -> bool {
         self.state == ShardState::Active
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ShardKey;
+    use std::hash::Hasher;
+    use twox_hash::XxHash64;
+
+    #[test]
+    fn hash_metric_name_matches_xxhash64_low_bits() {
+        let metric_names = ["cpu.usage", "mem.free", "http_requests_total"];
+
+        for metric_name in metric_names {
+            let mut hasher = XxHash64::with_seed(0);
+            hasher.write(metric_name.as_bytes());
+            let expected = (hasher.finish() & 0xFFFF) as u16;
+            assert_eq!(ShardKey::hash_metric_name(metric_name), expected);
+        }
     }
 }

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -718,7 +718,11 @@ impl ShardSplitter {
             max_timestamp,
             row_count: batch.num_rows() as u64,
             size_bytes: bytes_len as u64,
-            shard_id: path.split('/').next().map(str::to_string),
+            shard_id: path
+                .split('/')
+                .next()
+                .ok_or_else(|| crate::Error::Internal("Invalid shard chunk path".to_string()))?
+                .to_string(),
         };
         self.metadata.register_chunk(path, &metadata).await?;
 

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -3,7 +3,7 @@
 //! Each phase transition is persisted to object storage so that a crash at any
 //! point can be recovered by calling `resume_split()`.
 
-use super::{ShardId, ShardMetadata, ShardState, TimeBucket};
+use super::{midpoint_bytes, ShardId, ShardKey, ShardMetadata, ShardState, TimeBucket};
 use crate::ingester::ChunkMetadata;
 use crate::metadata::MetadataClient;
 use crate::Result;
@@ -331,7 +331,7 @@ impl ShardSplitter {
 
         let current_generation = old_metadata.generation;
         let split_ts =
-            i64::from_be_bytes(split_state.split_point[..8].try_into().unwrap_or([0u8; 8]));
+            Self::split_timestamp(&split_state.split_point).unwrap_or(old_metadata.max_time);
 
         // Step 1: Create shard A (idempotent — skipped if already done)
         if !progress.shard_a_created {
@@ -619,7 +619,7 @@ impl ShardSplitter {
 
     // ── Helpers ──────────────────────────────────────────────────────
 
-    /// Split a RecordBatch into two based on timestamp split point
+    /// Split a RecordBatch into two based on either a full shard-key or a legacy timestamp split point.
     fn split_batch(
         &self,
         batch: &RecordBatch,
@@ -643,15 +643,24 @@ impl ShardSplitter {
         let mut indices_a = Vec::new();
         let mut indices_b = Vec::new();
 
-        let split_ts = i64::from_be_bytes(
-            split_point
-                .try_into()
-                .map_err(|_| crate::Error::Internal("Invalid split point".to_string()))?,
-        );
-
         for i in 0..batch.num_rows() {
-            let ts = ts_array.value(i);
-            if ts < split_ts {
+            let split_left = match split_point.len() {
+                8 => {
+                    ts_array.value(i)
+                        < Self::split_timestamp(split_point).ok_or_else(|| {
+                            crate::Error::Internal("Invalid timestamp split point".to_string())
+                        })?
+                }
+                14 => self.row_key_for_split(batch, i, split_point)?.as_slice() < split_point,
+                _ => {
+                    return Err(crate::Error::Internal(format!(
+                        "Unsupported split point width {}",
+                        split_point.len()
+                    )))
+                }
+            };
+
+            if split_left {
                 indices_a.push(i as u32);
             } else {
                 indices_b.push(i as u32);
@@ -709,6 +718,7 @@ impl ShardSplitter {
             max_timestamp,
             row_count: batch.num_rows() as u64,
             size_bytes: bytes_len as u64,
+            shard_id: path.split('/').next().map(str::to_string),
         };
         self.metadata.register_chunk(path, &metadata).await?;
 
@@ -738,13 +748,49 @@ impl ShardSplitter {
         out
     }
 
-    /// Calculate the split point based on time
+    /// Calculate the split point from the shard's key range when possible.
     fn calculate_split_point(&self, shard: &ShardMetadata) -> Vec<u8> {
+        if let Some(midpoint) = midpoint_bytes(&shard.key_range.0, &shard.key_range.1) {
+            return midpoint;
+        }
+
         let time_range = shard.max_time - shard.min_time;
         let mid_time = shard.min_time + time_range / 2;
+        TimeBucket::round_to_5min(mid_time).to_be_bytes().to_vec()
+    }
 
-        let rounded = TimeBucket::round_to_5min(mid_time);
-        rounded.to_be_bytes().to_vec()
+    fn split_timestamp(split_point: &[u8]) -> Option<i64> {
+        match split_point.len() {
+            8 => Some(i64::from_be_bytes(split_point.try_into().ok()?)),
+            14 => Some(i64::from_be_bytes(split_point[6..14].try_into().ok()?)),
+            _ => None,
+        }
+    }
+
+    fn row_key_for_split(
+        &self,
+        batch: &RecordBatch,
+        row_idx: usize,
+        split_point: &[u8],
+    ) -> Result<Vec<u8>> {
+        let tenant_id =
+            u32::from_be_bytes(split_point[0..4].try_into().map_err(|_| {
+                crate::Error::Internal("Invalid shard-key split point".to_string())
+            })?);
+        let metric_name = batch
+            .column_by_name("metric_name")
+            .and_then(|column| column.as_any().downcast_ref::<arrow::array::StringArray>())
+            .ok_or_else(|| crate::Error::Internal("Missing metric_name column".to_string()))?
+            .value(row_idx);
+        let timestamp = batch
+            .column_by_name("timestamp")
+            .ok_or_else(|| crate::Error::Internal("Missing timestamp column".to_string()))?
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .ok_or_else(|| crate::Error::Internal("Timestamp not Int64".to_string()))?
+            .value(row_idx);
+
+        Ok(ShardKey::new(tenant_id, metric_name, timestamp).to_bytes())
     }
 }
 
@@ -801,7 +847,32 @@ mod tests {
         let split_point = splitter.calculate_split_point(&shard);
 
         assert!(!split_point.is_empty());
-        assert_eq!(split_point.len(), 8); // i64 bytes
+        assert_eq!(split_point.len(), shard.key_range.0.len());
+    }
+
+    #[tokio::test]
+    async fn test_split_point_uses_full_key_midpoint_when_available() {
+        let metadata = Arc::new(LocalMetadataClient::new());
+        let object_store = Arc::new(InMemory::new());
+        let splitter = ShardSplitter::new(metadata, object_store);
+
+        let start = ShardKey::new(0, "cpu", 0).to_bytes();
+        let end = ShardKey::new(0, "cpu", 600_000_000_000).to_bytes();
+        let shard = ShardMetadata {
+            shard_id: "shard-1".to_string(),
+            generation: 1,
+            key_range: (start.clone(), end.clone()),
+            replicas: vec![],
+            state: ShardState::Active,
+            min_time: 0,
+            max_time: 600_000_000_000,
+        };
+
+        let split_point = splitter.calculate_split_point(&shard);
+
+        assert_eq!(split_point.len(), 14);
+        assert!(split_point > start);
+        assert!(split_point < end);
     }
 
     #[tokio::test]

--- a/tests/atomic_metadata_tests.rs
+++ b/tests/atomic_metadata_tests.rs
@@ -36,7 +36,7 @@ async fn test_concurrent_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
-                shard_id: None,
+                shard_id: "test-shard".to_string(),
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -81,7 +81,7 @@ async fn test_atomic_retry_on_conflict() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&chunk.path, &chunk)
@@ -100,7 +100,7 @@ async fn test_atomic_retry_on_conflict() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 100,
                 size_bytes: 1024,
-                shard_id: None,
+                shard_id: "test-shard".to_string(),
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -160,7 +160,7 @@ async fn test_heavy_concurrent_load() {
                     max_timestamp: ((task_id * CHUNKS_PER_TASK + chunk_id) as i64 + 1) * 1000,
                     row_count: 1000,
                     size_bytes: 1024 * 1024,
-                    shard_id: None,
+                    shard_id: "test-shard".to_string(),
                 };
 
                 if client.register_chunk(&chunk.path, &chunk).await.is_ok() {
@@ -235,7 +235,7 @@ async fn test_atomic_compaction_completion() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -247,7 +247,7 @@ async fn test_atomic_compaction_completion() {
         max_timestamp: 3000,
         row_count: 3000,
         size_bytes: 3 * 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk("compacted.parquet", &target_chunk)
@@ -306,7 +306,7 @@ async fn test_concurrent_compactions() {
                 max_timestamp: ((group * 3 + chunk) as i64 + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
-                shard_id: None,
+                shard_id: "test-shard".to_string(),
             };
             metadata_client.register_chunk(&path, &meta).await.unwrap();
         }
@@ -319,7 +319,7 @@ async fn test_concurrent_compactions() {
             max_timestamp: ((group * 3) as i64 + 3) * 1000,
             row_count: 3000,
             size_bytes: 3 * 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client
             .register_chunk(&target, &meta)

--- a/tests/atomic_metadata_tests.rs
+++ b/tests/atomic_metadata_tests.rs
@@ -36,6 +36,7 @@ async fn test_concurrent_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
+                shard_id: None,
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -80,6 +81,7 @@ async fn test_atomic_retry_on_conflict() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&chunk.path, &chunk)
@@ -98,6 +100,7 @@ async fn test_atomic_retry_on_conflict() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 100,
                 size_bytes: 1024,
+                shard_id: None,
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -157,6 +160,7 @@ async fn test_heavy_concurrent_load() {
                     max_timestamp: ((task_id * CHUNKS_PER_TASK + chunk_id) as i64 + 1) * 1000,
                     row_count: 1000,
                     size_bytes: 1024 * 1024,
+                    shard_id: None,
                 };
 
                 if client.register_chunk(&chunk.path, &chunk).await.is_ok() {
@@ -231,6 +235,7 @@ async fn test_atomic_compaction_completion() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -242,6 +247,7 @@ async fn test_atomic_compaction_completion() {
         max_timestamp: 3000,
         row_count: 3000,
         size_bytes: 3 * 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk("compacted.parquet", &target_chunk)
@@ -300,6 +306,7 @@ async fn test_concurrent_compactions() {
                 max_timestamp: ((group * 3 + chunk) as i64 + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
+                shard_id: None,
             };
             metadata_client.register_chunk(&path, &meta).await.unwrap();
         }
@@ -312,6 +319,7 @@ async fn test_concurrent_compactions() {
             max_timestamp: ((group * 3) as i64 + 3) * 1000,
             row_count: 3000,
             size_bytes: 3 * 1024 * 1024,
+            shard_id: None,
         };
         metadata_client
             .register_chunk(&target, &meta)

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -842,7 +842,7 @@ async fn test_time_index_rebuild() {
             max_timestamp: (i + 1) * nanos_per_hour - 1,
             row_count: 100,
             size_bytes: 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -884,7 +884,7 @@ async fn test_compaction_level_tracking_through_metadata() {
             max_timestamp: (i + 1) * 1000 - 1,
             row_count: 10,
             size_bytes: 100,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -896,7 +896,7 @@ async fn test_compaction_level_tracking_through_metadata() {
         max_timestamp: 2999,
         row_count: 30,
         size_bytes: 300,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&target.path, &target).await.unwrap();
 
@@ -1231,7 +1231,7 @@ async fn test_concurrent_split_and_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 10,
                 size_bytes: 100,
-                shard_id: None,
+                shard_id: "test-shard".to_string(),
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
         });
@@ -1263,7 +1263,7 @@ async fn test_concurrent_split_and_chunk_registration() {
             max_timestamp: (i + 1) * 1000,
             row_count: 10,
             size_bytes: 100,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -842,6 +842,7 @@ async fn test_time_index_rebuild() {
             max_timestamp: (i + 1) * nanos_per_hour - 1,
             row_count: 100,
             size_bytes: 1024,
+            shard_id: None,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -883,6 +884,7 @@ async fn test_compaction_level_tracking_through_metadata() {
             max_timestamp: (i + 1) * 1000 - 1,
             row_count: 10,
             size_bytes: 100,
+            shard_id: None,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -894,6 +896,7 @@ async fn test_compaction_level_tracking_through_metadata() {
         max_timestamp: 2999,
         row_count: 30,
         size_bytes: 300,
+        shard_id: None,
     };
     client.register_chunk(&target.path, &target).await.unwrap();
 
@@ -1228,6 +1231,7 @@ async fn test_concurrent_split_and_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 10,
                 size_bytes: 100,
+                shard_id: None,
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
         });
@@ -1259,6 +1263,7 @@ async fn test_concurrent_split_and_chunk_registration() {
             max_timestamp: (i + 1) * 1000,
             row_count: 10,
             size_bytes: 100,
+            shard_id: None,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }

--- a/tests/error_path_tests.rs
+++ b/tests/error_path_tests.rs
@@ -225,7 +225,7 @@ async fn test_get_nonexistent_chunk() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -265,7 +265,7 @@ async fn test_list_chunks_uninitialized_metadata() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
     client.delete_chunk("temp.parquet").await.unwrap();
@@ -296,7 +296,7 @@ async fn test_get_chunks_empty_time_range() {
         max_timestamp: 2000,
         row_count: 100,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -332,7 +332,7 @@ async fn test_metadata_cas_fails_loudly_when_unsafe_overwrite_disabled() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     client
@@ -346,7 +346,7 @@ async fn test_metadata_cas_fails_loudly_when_unsafe_overwrite_disabled() {
         max_timestamp: 3000,
         row_count: 20,
         size_bytes: 200,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     let result = client.register_chunk(&second.path, &second).await;
@@ -391,7 +391,7 @@ async fn test_metadata_cas_fallback_overwrite_when_enabled() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     client
@@ -405,7 +405,7 @@ async fn test_metadata_cas_fallback_overwrite_when_enabled() {
         max_timestamp: 3000,
         row_count: 20,
         size_bytes: 200,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     client
@@ -452,7 +452,7 @@ async fn test_register_chunk_with_zero_timestamps() {
         max_timestamp: 0,
         row_count: 0,
         size_bytes: 0,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
@@ -486,7 +486,7 @@ async fn test_register_duplicate_chunk_path() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     let chunk2 = ChunkMetadata {
@@ -495,7 +495,7 @@ async fn test_register_duplicate_chunk_path() {
         max_timestamp: 3000,
         row_count: 200,
         size_bytes: 2048,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     client.register_chunk(&chunk1.path, &chunk1).await.unwrap();
@@ -632,7 +632,7 @@ async fn test_compaction_with_single_source() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&source.path, &source).await.unwrap();
 
@@ -642,7 +642,7 @@ async fn test_compaction_with_single_source() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&target.path, &target).await.unwrap();
 
@@ -686,7 +686,7 @@ async fn test_l0_candidates_empty() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
     let target = ChunkMetadata {
@@ -695,7 +695,7 @@ async fn test_l0_candidates_empty() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&target.path, &target).await.unwrap();
     client
@@ -730,7 +730,7 @@ async fn test_level_candidates_nonexistent_level() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -1088,7 +1088,7 @@ async fn test_concurrent_registration_data_integrity() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: (i + 1) as u64 * 100, // Unique row count per chunk
                 size_bytes: (i + 1) as u64 * 1024,
-                shard_id: None,
+                shard_id: "test-shard".to_string(),
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
             (i, chunk.row_count)

--- a/tests/error_path_tests.rs
+++ b/tests/error_path_tests.rs
@@ -225,6 +225,7 @@ async fn test_get_nonexistent_chunk() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -264,6 +265,7 @@ async fn test_list_chunks_uninitialized_metadata() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
     client.delete_chunk("temp.parquet").await.unwrap();
@@ -294,6 +296,7 @@ async fn test_get_chunks_empty_time_range() {
         max_timestamp: 2000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: None,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -329,6 +332,7 @@ async fn test_metadata_cas_fails_loudly_when_unsafe_overwrite_disabled() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
 
     client
@@ -342,6 +346,7 @@ async fn test_metadata_cas_fails_loudly_when_unsafe_overwrite_disabled() {
         max_timestamp: 3000,
         row_count: 20,
         size_bytes: 200,
+        shard_id: None,
     };
 
     let result = client.register_chunk(&second.path, &second).await;
@@ -386,6 +391,7 @@ async fn test_metadata_cas_fallback_overwrite_when_enabled() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
 
     client
@@ -399,6 +405,7 @@ async fn test_metadata_cas_fallback_overwrite_when_enabled() {
         max_timestamp: 3000,
         row_count: 20,
         size_bytes: 200,
+        shard_id: None,
     };
 
     client
@@ -445,6 +452,7 @@ async fn test_register_chunk_with_zero_timestamps() {
         max_timestamp: 0,
         row_count: 0,
         size_bytes: 0,
+        shard_id: None,
     };
 
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
@@ -478,6 +486,7 @@ async fn test_register_duplicate_chunk_path() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: None,
     };
 
     let chunk2 = ChunkMetadata {
@@ -486,6 +495,7 @@ async fn test_register_duplicate_chunk_path() {
         max_timestamp: 3000,
         row_count: 200,
         size_bytes: 2048,
+        shard_id: None,
     };
 
     client.register_chunk(&chunk1.path, &chunk1).await.unwrap();
@@ -622,6 +632,7 @@ async fn test_compaction_with_single_source() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: None,
     };
     client.register_chunk(&source.path, &source).await.unwrap();
 
@@ -631,6 +642,7 @@ async fn test_compaction_with_single_source() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: None,
     };
     client.register_chunk(&target.path, &target).await.unwrap();
 
@@ -674,6 +686,7 @@ async fn test_l0_candidates_empty() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
     let target = ChunkMetadata {
@@ -682,6 +695,7 @@ async fn test_l0_candidates_empty() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
     client.register_chunk(&target.path, &target).await.unwrap();
     client
@@ -716,6 +730,7 @@ async fn test_level_candidates_nonexistent_level() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: None,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -988,7 +1003,10 @@ async fn test_ingester_buffer_below_threshold_no_flush() {
         stats.row_count, 2,
         "Buffer should retain rows below threshold"
     );
-    assert_eq!(stats.batch_count, 1);
+    assert_eq!(
+        stats.batch_count, 2,
+        "Mixed-shard writes should remain isolated in shard-local buffers"
+    );
 
     // No chunks should be registered
     let chunks = metadata.list_chunks().await.unwrap();
@@ -1070,6 +1088,7 @@ async fn test_concurrent_registration_data_integrity() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: (i + 1) as u64 * 100, // Unique row count per chunk
                 size_bytes: (i + 1) as u64 * 1024,
+                shard_id: None,
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
             (i, chunk.row_count)

--- a/tests/ingest_sharding_tests.rs
+++ b/tests/ingest_sharding_tests.rs
@@ -1,0 +1,146 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use arrow_array::{Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+use cardinalsin::ingester::{ChunkMetadata, Ingester, IngesterConfig};
+use cardinalsin::metadata::{LocalMetadataClient, MetadataClient};
+use cardinalsin::schema::MetricSchema;
+use cardinalsin::sharding::{HotShardConfig, ShardKey};
+use cardinalsin::{CloudProvider, StorageConfig};
+use object_store::memory::InMemory;
+
+fn make_batch(rows: &[(i64, &str)]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::Int64, false),
+        Field::new("metric_name", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+
+    let timestamps = Int64Array::from(rows.iter().map(|(ts, _)| *ts).collect::<Vec<_>>());
+    let metrics = StringArray::from(rows.iter().map(|(_, metric)| *metric).collect::<Vec<_>>());
+    let values = Float64Array::from((0..rows.len()).map(|i| i as f64).collect::<Vec<_>>());
+
+    RecordBatch::try_new(
+        schema,
+        vec![Arc::new(timestamps), Arc::new(metrics), Arc::new(values)],
+    )
+    .unwrap()
+}
+
+fn make_ingester(
+    metadata: Arc<LocalMetadataClient>,
+    tenant_id: u32,
+    flush_row_count: usize,
+) -> Ingester {
+    let config = IngesterConfig {
+        flush_interval: Duration::from_secs(3600),
+        flush_row_count,
+        flush_size_bytes: usize::MAX,
+        ..Default::default()
+    };
+    let store = Arc::new(InMemory::new());
+    let storage_config = StorageConfig {
+        provider: CloudProvider::Memory,
+        container: "test-bucket".to_string(),
+        tenant_id: "tenant-a".to_string(),
+    };
+    let metadata_client: Arc<dyn MetadataClient> = metadata;
+
+    Ingester::with_shard_config(
+        config,
+        store,
+        metadata_client,
+        storage_config,
+        MetricSchema::default_metrics(),
+        HotShardConfig::default(),
+        tenant_id,
+    )
+}
+
+#[tokio::test]
+async fn mixed_batch_flushes_to_separate_shard_paths_and_metadata() {
+    let metadata = Arc::new(LocalMetadataClient::new());
+    let ingester = make_ingester(metadata.clone(), 7, 1);
+
+    let ts_a = 1_700_000_000_000_000_000i64;
+    let ts_b = ts_a + (5 * 60 * 1_000_000_000i64);
+    let batch = make_batch(&[(ts_a, "cpu_usage"), (ts_b, "cpu_usage")]);
+
+    ingester.write(batch).await.unwrap();
+
+    let chunks = metadata.list_chunks().await.unwrap();
+    assert_eq!(
+        chunks.len(),
+        2,
+        "mixed-shard writes should flush separately"
+    );
+
+    let expected_a = ShardKey::new(7, "cpu_usage", ts_a).shard_id();
+    let expected_b = ShardKey::new(7, "cpu_usage", ts_b).shard_id();
+    let expected: HashSet<_> = [expected_a.clone(), expected_b.clone()]
+        .into_iter()
+        .collect();
+    let actual: HashSet<_> = chunks
+        .iter()
+        .map(|chunk| {
+            chunk
+                .shard_id
+                .clone()
+                .expect("chunk should record shard_id")
+        })
+        .collect();
+    assert_eq!(actual, expected);
+
+    for chunk in &chunks {
+        let shard_id = chunk.shard_id.as_deref().unwrap();
+        assert!(
+            chunk.chunk_path.contains(&format!("shard={shard_id}")),
+            "chunk path should include its shard id: {}",
+            chunk.chunk_path
+        );
+    }
+
+    assert_eq!(
+        metadata
+            .get_chunks_for_shard(&expected_a)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        metadata
+            .get_chunks_for_shard(&expected_b)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn local_metadata_prefers_explicit_shard_id_over_path_matching() {
+    let metadata = LocalMetadataClient::new();
+    let chunk = ChunkMetadata {
+        path: "tenant-a/data/year=2026/month=03/day=10/hour=00/chunk.parquet".to_string(),
+        min_timestamp: 100,
+        max_timestamp: 200,
+        row_count: 2,
+        size_bytes: 128,
+        shard_id: Some("shard-explicit".to_string()),
+    };
+
+    metadata.register_chunk(&chunk.path, &chunk).await.unwrap();
+
+    let matching = metadata
+        .get_chunks_for_shard("shard-explicit")
+        .await
+        .unwrap();
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].chunk_path, chunk.path);
+
+    let non_matching = metadata.get_chunks_for_shard("shard-other").await.unwrap();
+    assert!(non_matching.is_empty());
+}

--- a/tests/ingest_sharding_tests.rs
+++ b/tests/ingest_sharding_tests.rs
@@ -82,19 +82,11 @@ async fn mixed_batch_flushes_to_separate_shard_paths_and_metadata() {
     let expected: HashSet<_> = [expected_a.clone(), expected_b.clone()]
         .into_iter()
         .collect();
-    let actual: HashSet<_> = chunks
-        .iter()
-        .map(|chunk| {
-            chunk
-                .shard_id
-                .clone()
-                .expect("chunk should record shard_id")
-        })
-        .collect();
+    let actual: HashSet<_> = chunks.iter().map(|chunk| chunk.shard_id.clone()).collect();
     assert_eq!(actual, expected);
 
     for chunk in &chunks {
-        let shard_id = chunk.shard_id.as_deref().unwrap();
+        let shard_id = chunk.shard_id.as_str();
         assert!(
             chunk.chunk_path.contains(&format!("shard={shard_id}")),
             "chunk path should include its shard id: {}",
@@ -129,7 +121,7 @@ async fn local_metadata_prefers_explicit_shard_id_over_path_matching() {
         max_timestamp: 200,
         row_count: 2,
         size_bytes: 128,
-        shard_id: Some("shard-explicit".to_string()),
+        shard_id: "shard-explicit".to_string(),
     };
 
     metadata.register_chunk(&chunk.path, &chunk).await.unwrap();

--- a/tests/level_tracking_tests.rs
+++ b/tests/level_tracking_tests.rs
@@ -29,6 +29,7 @@ async fn test_new_chunks_start_at_l0() {
         max_timestamp: 1000,
         row_count: 1000,
         size_bytes: 1024 * 1024,
+        shard_id: None,
     };
 
     metadata_client
@@ -74,6 +75,7 @@ async fn test_l0_to_l1_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -85,6 +87,7 @@ async fn test_l0_to_l1_progression() {
         max_timestamp: 3000,
         row_count: 3000,
         size_bytes: 3 * 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&l1_chunk.path, &l1_chunk)
@@ -144,6 +147,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -154,6 +158,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 2000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&l1_chunk_1.path, &l1_chunk_1)
@@ -174,6 +179,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: ((i + 2) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -184,6 +190,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 4000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&l1_chunk_2.path, &l1_chunk_2)
@@ -202,6 +209,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 4000,
         row_count: 4000,
         size_bytes: 4 * 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&l2_chunk.path, &l2_chunk)
@@ -274,6 +282,7 @@ async fn test_full_level_progression() {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         client.register_chunk(target, &chunk).await.unwrap();
 
@@ -294,6 +303,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -350,6 +360,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -420,6 +431,7 @@ async fn test_level_filtering() {
         max_timestamp: 1000,
         row_count: 1000,
         size_bytes: 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&l0_chunk.path, &l0_chunk)
@@ -435,6 +447,7 @@ async fn test_level_filtering() {
             max_timestamp: ((i + 1) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: None,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -445,6 +458,7 @@ async fn test_level_filtering() {
         max_timestamp: 3000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
+        shard_id: None,
     };
     metadata_client
         .register_chunk(&l1_target.path, &l1_target)

--- a/tests/level_tracking_tests.rs
+++ b/tests/level_tracking_tests.rs
@@ -29,7 +29,7 @@ async fn test_new_chunks_start_at_l0() {
         max_timestamp: 1000,
         row_count: 1000,
         size_bytes: 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     metadata_client
@@ -75,7 +75,7 @@ async fn test_l0_to_l1_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -87,7 +87,7 @@ async fn test_l0_to_l1_progression() {
         max_timestamp: 3000,
         row_count: 3000,
         size_bytes: 3 * 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&l1_chunk.path, &l1_chunk)
@@ -147,7 +147,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -158,7 +158,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 2000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&l1_chunk_1.path, &l1_chunk_1)
@@ -179,7 +179,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: ((i + 2) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -190,7 +190,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 4000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&l1_chunk_2.path, &l1_chunk_2)
@@ -209,7 +209,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 4000,
         row_count: 4000,
         size_bytes: 4 * 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&l2_chunk.path, &l2_chunk)
@@ -282,7 +282,7 @@ async fn test_full_level_progression() {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         client.register_chunk(target, &chunk).await.unwrap();
 
@@ -303,7 +303,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -360,7 +360,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -431,7 +431,7 @@ async fn test_level_filtering() {
         max_timestamp: 1000,
         row_count: 1000,
         size_bytes: 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&l0_chunk.path, &l0_chunk)
@@ -447,7 +447,7 @@ async fn test_level_filtering() {
             max_timestamp: ((i + 1) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-            shard_id: None,
+            shard_id: "test-shard".to_string(),
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -458,7 +458,7 @@ async fn test_level_filtering() {
         max_timestamp: 3000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
     metadata_client
         .register_chunk(&l1_target.path, &l1_target)

--- a/tests/metadata_shard_identity_tests.rs
+++ b/tests/metadata_shard_identity_tests.rs
@@ -1,0 +1,61 @@
+use cardinalsin::ingester::ChunkMetadata;
+use cardinalsin::metadata::{MetadataClient, S3MetadataClient, S3MetadataConfig};
+use object_store::memory::InMemory;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn local_metadata_rejects_empty_shard_id() {
+    let metadata = cardinalsin::metadata::LocalMetadataClient::new();
+    let chunk = ChunkMetadata {
+        path: "tenant-a/data/shard=path-shard/year=2026/month=03/day=09/hour=00/chunk.parquet"
+            .to_string(),
+        min_timestamp: 100,
+        max_timestamp: 200,
+        row_count: 2,
+        size_bytes: 128,
+        shard_id: String::new(),
+    };
+
+    let err = metadata
+        .register_chunk(&chunk.path, &chunk)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("shard_id"),
+        "registration should fail when shard_id is missing: {err}"
+    );
+}
+
+#[tokio::test]
+async fn object_store_metadata_rejects_empty_shard_id() {
+    let store = Arc::new(InMemory::new());
+    let client = S3MetadataClient::new(
+        store,
+        S3MetadataConfig {
+            bucket: "test-bucket".to_string(),
+            metadata_prefix: "test/".to_string(),
+            enable_cache: true,
+            allow_unsafe_overwrite: false,
+            ..Default::default()
+        },
+    );
+
+    let chunk = ChunkMetadata {
+        path: "tenant-a/data/shard=path-shard/year=2026/month=03/day=09/hour=00/chunk.parquet"
+            .to_string(),
+        min_timestamp: 100,
+        max_timestamp: 200,
+        row_count: 2,
+        size_bytes: 128,
+        shard_id: String::new(),
+    };
+
+    let err = client
+        .register_chunk(&chunk.path, &chunk)
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("shard_id"),
+        "registration should fail when shard_id is missing: {err}"
+    );
+}

--- a/tests/predicate_pushdown_tests.rs
+++ b/tests/predicate_pushdown_tests.rs
@@ -37,6 +37,7 @@ async fn register_chunk_with_stats(
         max_timestamp: max_ts,
         row_count: 1000,
         size_bytes: 100_000,
+        shard_id: None,
     };
 
     client.register_chunk(path, &chunk).await.unwrap();

--- a/tests/predicate_pushdown_tests.rs
+++ b/tests/predicate_pushdown_tests.rs
@@ -37,7 +37,7 @@ async fn register_chunk_with_stats(
         max_timestamp: max_ts,
         row_count: 1000,
         size_bytes: 100_000,
-        shard_id: None,
+        shard_id: "test-shard".to_string(),
     };
 
     client.register_chunk(path, &chunk).await.unwrap();

--- a/tests/query_shard_pruning_tests.rs
+++ b/tests/query_shard_pruning_tests.rs
@@ -1,0 +1,278 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cardinalsin::ingester::ChunkMetadata;
+use cardinalsin::metadata::predicates::ColumnPredicate;
+use cardinalsin::metadata::{
+    CompactionJob, CompactionLease, CompactionLeases, CompactionStatus, LeaseStatus,
+    MetadataClient, SplitState, TimeIndexEntry, TimeRange,
+};
+use cardinalsin::query::{
+    QueryConfig, QueryEngine, QueryNode, StreamingQueryExecutor, TieredCache,
+};
+use cardinalsin::sharding::{ShardKey, ShardMetadata, ShardState, SplitPhase};
+use cardinalsin::{CloudProvider, Error, Result, StorageConfig};
+use object_store::memory::InMemory;
+use tokio::sync::broadcast;
+use tokio::sync::Mutex;
+
+#[derive(Default)]
+struct RecordingMetadata {
+    shards: Vec<ShardMetadata>,
+    requested_shards: Mutex<Vec<String>>,
+}
+
+impl RecordingMetadata {
+    fn new(shards: Vec<ShardMetadata>) -> Self {
+        Self {
+            shards,
+            requested_shards: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn requested_shards(&self) -> Vec<String> {
+        self.requested_shards.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl MetadataClient for RecordingMetadata {
+    async fn register_chunk(&self, _path: &str, _metadata: &ChunkMetadata) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_chunks(&self, _range: TimeRange) -> Result<Vec<TimeIndexEntry>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_chunks_with_predicates(
+        &self,
+        _range: TimeRange,
+        _predicates: &[ColumnPredicate],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        Err(Error::Internal(
+            "expected shard-scoped metadata lookup".to_string(),
+        ))
+    }
+
+    async fn get_chunks_with_predicates_for_shards(
+        &self,
+        _range: TimeRange,
+        _predicates: &[ColumnPredicate],
+        shard_ids: &[String],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        *self.requested_shards.lock().await = shard_ids.to_vec();
+        Ok(Vec::new())
+    }
+
+    async fn get_chunk(&self, _path: &str) -> Result<Option<ChunkMetadata>> {
+        Ok(None)
+    }
+
+    async fn delete_chunk(&self, _path: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn list_chunks(&self) -> Result<Vec<TimeIndexEntry>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_l0_candidates(&self, _min_count: usize) -> Result<Vec<Vec<String>>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_level_candidates(
+        &self,
+        _level: usize,
+        _target_size: usize,
+    ) -> Result<Vec<Vec<String>>> {
+        Ok(Vec::new())
+    }
+
+    async fn create_compaction_job(&self, _job: CompactionJob) -> Result<()> {
+        Ok(())
+    }
+
+    async fn complete_compaction(
+        &self,
+        _source_chunks: &[String],
+        _target_chunk: &str,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn update_compaction_status(
+        &self,
+        _job_id: &str,
+        _status: CompactionStatus,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_pending_compaction_jobs(&self) -> Result<Vec<CompactionJob>> {
+        Ok(Vec::new())
+    }
+
+    async fn start_split(
+        &self,
+        _old_shard: &str,
+        _new_shards: Vec<String>,
+        _split_point: Vec<u8>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_split_state(&self, _shard_id: &str) -> Result<Option<SplitState>> {
+        Ok(None)
+    }
+
+    async fn update_split_progress(
+        &self,
+        _shard_id: &str,
+        _progress: f64,
+        _phase: SplitPhase,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn complete_split(&self, _old_shard: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_chunks_for_shard(&self, _shard_id: &str) -> Result<Vec<TimeIndexEntry>> {
+        Ok(Vec::new())
+    }
+
+    async fn get_shard_metadata(&self, shard_id: &str) -> Result<Option<ShardMetadata>> {
+        Ok(self
+            .shards
+            .iter()
+            .find(|shard| shard.shard_id == shard_id)
+            .cloned())
+    }
+
+    async fn update_shard_metadata(
+        &self,
+        _shard_id: &str,
+        _metadata: &ShardMetadata,
+        _expected_generation: u64,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn list_shards(&self) -> Result<Vec<ShardMetadata>> {
+        Ok(self.shards.clone())
+    }
+
+    async fn acquire_lease(
+        &self,
+        node_id: &str,
+        chunks: &[String],
+        level: u32,
+    ) -> Result<CompactionLease> {
+        let now = chrono::Utc::now();
+        Ok(CompactionLease {
+            lease_id: "lease".to_string(),
+            holder_id: node_id.to_string(),
+            chunks: chunks.to_vec(),
+            acquired_at: now,
+            expires_at: now,
+            level,
+            status: LeaseStatus::Active,
+        })
+    }
+
+    async fn complete_lease(&self, _lease_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn fail_lease(&self, _lease_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn renew_lease(&self, _lease_id: &str) -> Result<()> {
+        Ok(())
+    }
+
+    async fn load_leases(&self) -> Result<CompactionLeases> {
+        Ok(CompactionLeases::default())
+    }
+
+    async fn scavenge_leases(&self) -> Result<usize> {
+        Ok(0)
+    }
+
+    async fn has_active_split(&self) -> Result<bool> {
+        Ok(false)
+    }
+}
+
+fn storage_config() -> StorageConfig {
+    StorageConfig {
+        provider: CloudProvider::Memory,
+        container: "test-bucket".to_string(),
+        tenant_id: "tenant-a".to_string(),
+    }
+}
+
+async fn make_query_node(metadata: Arc<dyn MetadataClient>) -> QueryNode {
+    let store = Arc::new(InMemory::new());
+    QueryNode::new(QueryConfig::default(), store, metadata, storage_config())
+        .await
+        .unwrap()
+}
+
+async fn make_engine() -> QueryEngine {
+    let store = Arc::new(InMemory::new());
+    let cache = Arc::new(TieredCache::new(Default::default()).await.unwrap());
+    QueryEngine::new(store, cache, &storage_config())
+        .await
+        .unwrap()
+}
+
+fn shard_for(metric_name: &str, ts: i64) -> ShardMetadata {
+    let key = ShardKey::new(0, metric_name, ts);
+    let start = key.to_bytes();
+    let mut end = start.clone();
+    *end.last_mut().unwrap() += 1;
+    ShardMetadata {
+        shard_id: key.shard_id(),
+        generation: 1,
+        key_range: (start, end),
+        replicas: Vec::new(),
+        state: ShardState::Active,
+        min_time: ts,
+        max_time: ts + 300_000_000_000,
+    }
+}
+
+#[tokio::test]
+async fn query_node_uses_shard_scoped_metadata_lookup() {
+    let ts = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+    let shard = shard_for("cpu_usage", ts);
+    let metadata = Arc::new(RecordingMetadata::new(vec![shard.clone()]));
+    let node = make_query_node(metadata.clone()).await;
+
+    node.query_for_tenant("SELECT * FROM metrics WHERE metric_name = 'cpu_usage'", "0")
+        .await
+        .unwrap();
+
+    assert_eq!(metadata.requested_shards().await, vec![shard.shard_id]);
+}
+
+#[tokio::test]
+async fn streaming_query_uses_shard_scoped_metadata_lookup() {
+    let ts = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0);
+    let shard = shard_for("cpu_usage", ts);
+    let metadata = Arc::new(RecordingMetadata::new(vec![shard.clone()]));
+    let engine = make_engine().await;
+    let (_tx, rx) = broadcast::channel(8);
+    let executor = StreamingQueryExecutor::new(engine, metadata.clone(), rx);
+
+    let _receiver = executor
+        .execute("SELECT * FROM metrics WHERE metric_name = 'cpu_usage'")
+        .await
+        .unwrap();
+
+    assert_eq!(metadata.requested_shards().await, vec![shard.shard_id]);
+}

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -157,7 +157,7 @@ async fn test_phase3_backfill() {
         max_timestamp: 5000,
         row_count: 5,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: shard.shard_id.clone(),
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -362,7 +362,7 @@ async fn test_phase5_cleanup() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: shard.shard_id.clone(),
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -432,7 +432,7 @@ async fn test_full_split_execution() {
         max_timestamp: 4000,
         row_count: 4,
         size_bytes: 1024,
-        shard_id: None,
+        shard_id: shard.shard_id.clone(),
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -533,7 +533,7 @@ async fn test_backfill_progress_tracking() {
             max_timestamp: i * 1000 + 1000,
             row_count: 2,
             size_bytes: 1024,
-            shard_id: None,
+            shard_id: shard.shard_id.clone(),
         };
         metadata
             .register_chunk(&chunk_path, &chunk_meta)
@@ -612,7 +612,7 @@ async fn test_backfill_rerun_is_idempotent() {
                 max_timestamp: 5000,
                 row_count: 5,
                 size_bytes: 1024,
-                shard_id: None,
+                shard_id: shard.shard_id.clone(),
             },
         )
         .await
@@ -732,7 +732,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 2000,
                 row_count: 3,
                 size_bytes: 1024,
-                shard_id: None,
+                shard_id: shard.shard_id.clone(),
             },
         )
         .await
@@ -748,7 +748,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 5000,
                 row_count: 3,
                 size_bytes: 1024,
-                shard_id: None,
+                shard_id: shard.shard_id.clone(),
             },
         )
         .await

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -157,6 +157,7 @@ async fn test_phase3_backfill() {
         max_timestamp: 5000,
         row_count: 5,
         size_bytes: 1024,
+        shard_id: None,
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -361,6 +362,7 @@ async fn test_phase5_cleanup() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: None,
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -430,6 +432,7 @@ async fn test_full_split_execution() {
         max_timestamp: 4000,
         row_count: 4,
         size_bytes: 1024,
+        shard_id: None,
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -530,6 +533,7 @@ async fn test_backfill_progress_tracking() {
             max_timestamp: i * 1000 + 1000,
             row_count: 2,
             size_bytes: 1024,
+            shard_id: None,
         };
         metadata
             .register_chunk(&chunk_path, &chunk_meta)
@@ -608,6 +612,7 @@ async fn test_backfill_rerun_is_idempotent() {
                 max_timestamp: 5000,
                 row_count: 5,
                 size_bytes: 1024,
+                shard_id: None,
             },
         )
         .await
@@ -727,6 +732,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 2000,
                 row_count: 3,
                 size_bytes: 1024,
+                shard_id: None,
             },
         )
         .await
@@ -742,6 +748,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 5000,
                 row_count: 3,
                 size_bytes: 1024,
+                shard_id: None,
             },
         )
         .await


### PR DESCRIPTION
## Summary
- make ingest buffering, flush, and chunk metadata shard-aware end to end
- require explicit shard identity in chunk metadata and remove path-based shard inference from metadata lookups
- add shard-scoped metadata lookup and query pruning for historical and streaming queries
- align split handling with full shard-key ranges

## Issues
- closes #171
- closes #172
- closes #174
- closes #175
- closes #176
- closes #177

## Testing
- cargo test -q --test metadata_shard_identity_tests
- cargo test -q --test ingest_sharding_tests
- cargo test -q --test query_shard_pruning_tests
- cargo test -q --test shard_split_tests -- --skip test_full_split_execution
- cargo test -q --test predicate_pushdown_tests --test atomic_metadata_tests --test error_path_tests --test level_tracking_tests
- cargo test -q -- --skip test_full_split_execution
