### PR TITLE
feat(ingest): route shard writes through distributed dispatcher

### DIFF
--- a/src/api/grpc.rs
+++ b/src/api/grpc.rs
@@ -2,8 +2,8 @@
 
 use crate::api::ingest::flight_ingest::FlightIngestService;
 use crate::api::ingest::otlp::{export_request_to_arrow, OtlpReceiver};
+use crate::api::ingest::IngestDispatcher;
 use crate::api::query::flight_sql::{batches_to_flight_data, FlightSqlQueryService};
-use crate::ingester::Ingester;
 use crate::query::QueryNode;
 use crate::{Error, Result};
 
@@ -60,11 +60,11 @@ const DEFAULT_FLIGHT_SQL_SCHEMA: &str = "public";
 /// Run ingester-side gRPC server (OTLP + Flight ingest).
 pub async fn run_ingester_grpc_server(
     addr: SocketAddr,
-    ingester: Arc<Ingester>,
+    ingest_dispatcher: Arc<IngestDispatcher>,
     shutdown: watch::Receiver<bool>,
 ) -> Result<()> {
-    let otlp = OtlpGrpcService::new(ingester.clone());
-    let flight = FlightIngestGrpcService::new(ingester);
+    let otlp = OtlpGrpcService::new(ingest_dispatcher.clone());
+    let flight = FlightIngestGrpcService::new(ingest_dispatcher);
 
     Server::builder()
         .add_service(MetricsServiceServer::new(otlp))
@@ -171,9 +171,9 @@ pub struct OtlpGrpcService {
 }
 
 impl OtlpGrpcService {
-    pub fn new(ingester: Arc<Ingester>) -> Self {
+    pub fn new(dispatcher: Arc<IngestDispatcher>) -> Self {
         Self {
-            receiver: OtlpReceiver::new(ingester),
+            receiver: OtlpReceiver::new(dispatcher),
         }
     }
 }
@@ -200,9 +200,9 @@ pub struct FlightIngestGrpcService {
 }
 
 impl FlightIngestGrpcService {
-    pub fn new(ingester: Arc<Ingester>) -> Self {
+    pub fn new(dispatcher: Arc<IngestDispatcher>) -> Self {
         Self {
-            ingest: Arc::new(FlightIngestService::new(ingester)),
+            ingest: Arc::new(FlightIngestService::new(dispatcher)),
         }
     }
 

--- a/src/api/ingest/dispatcher.rs
+++ b/src/api/ingest/dispatcher.rs
@@ -1,0 +1,101 @@
+use crate::api::ApiState;
+use crate::cluster::NodeInfo;
+use crate::ingester::{decode_record_batch_ipc, Ingester};
+use crate::Result;
+
+use arrow_array::RecordBatch;
+use async_trait::async_trait;
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::StatusCode;
+use std::sync::Arc;
+
+/// Minimal router surface needed by the ingest dispatcher.
+#[async_trait]
+pub trait ShardWriteRouter: Send + Sync {
+    async fn route_write(&self, shard_id: &str) -> Result<Option<NodeInfo>>;
+    async fn forward_write(
+        &self,
+        target_node: &NodeInfo,
+        batch: &RecordBatch,
+        tenant_id: &str,
+    ) -> Result<()>;
+}
+
+/// Runtime routing configuration for distributed ingest dispatch.
+#[derive(Clone)]
+pub struct RoutingContext {
+    router: Arc<dyn ShardWriteRouter>,
+    local_node_id: String,
+    tenant_id: String,
+}
+
+impl RoutingContext {
+    pub fn new(
+        router: Arc<dyn ShardWriteRouter>,
+        local_node_id: String,
+        tenant_id: String,
+    ) -> Self {
+        Self {
+            router,
+            local_node_id,
+            tenant_id,
+        }
+    }
+}
+
+/// Shared dispatcher used by HTTP and gRPC ingest protocols.
+#[derive(Clone)]
+pub struct IngestDispatcher {
+    ingester: Arc<Ingester>,
+    routing: Option<RoutingContext>,
+}
+
+impl IngestDispatcher {
+    pub fn new(ingester: Arc<Ingester>, routing: Option<RoutingContext>) -> Self {
+        Self { ingester, routing }
+    }
+
+    pub async fn dispatch(&self, batch: RecordBatch) -> Result<()> {
+        let Some(routing) = &self.routing else {
+            return self.ingester.write(batch).await;
+        };
+
+        let shard_batches = self.ingester.partition_batch_for_routing(&batch).await?;
+        for (shard_id, shard_batch) in shard_batches {
+            match routing.router.route_write(&shard_id).await? {
+                Some(target) if target.id != routing.local_node_id => {
+                    routing
+                        .router
+                        .forward_write(&target, &shard_batch, &routing.tenant_id)
+                        .await?;
+                }
+                _ => {
+                    self.ingester.write(shard_batch).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Internal Arrow IPC ingest endpoint used for shard forwarding between ingesters.
+pub async fn handle_internal_arrow_ingest(
+    State(state): State<ApiState>,
+    body: Bytes,
+) -> StatusCode {
+    let Some(ingester) = state.ingester else {
+        return StatusCode::SERVICE_UNAVAILABLE;
+    };
+
+    let batch = match decode_record_batch_ipc(&body) {
+        Ok(batch) => batch,
+        Err(_) => return StatusCode::BAD_REQUEST,
+    };
+
+    match ingester.write(batch).await {
+        Ok(_) => StatusCode::NO_CONTENT,
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}

--- a/src/api/ingest/flight_ingest.rs
+++ b/src/api/ingest/flight_ingest.rs
@@ -2,7 +2,7 @@
 //!
 //! High-performance bulk data loading via Arrow Flight DoPut.
 
-use crate::ingester::Ingester;
+use crate::api::ingest::IngestDispatcher;
 use crate::Result;
 
 use arrow_array::RecordBatch;
@@ -12,13 +12,13 @@ use std::sync::Arc;
 
 /// Arrow Flight ingestion service
 pub struct FlightIngestService {
-    ingester: Arc<Ingester>,
+    dispatcher: Arc<IngestDispatcher>,
 }
 
 impl FlightIngestService {
     /// Create a new Flight ingestion service
-    pub fn new(ingester: Arc<Ingester>) -> Self {
-        Self { ingester }
+    pub fn new(dispatcher: Arc<IngestDispatcher>) -> Self {
+        Self { dispatcher }
     }
 
     /// Process a stream of FlightData messages
@@ -39,7 +39,7 @@ impl FlightIngestService {
         let mut total_rows = 0u64;
         for batch in batches {
             total_rows += batch.num_rows() as u64;
-            self.ingester.write(batch).await?;
+            self.dispatcher.dispatch(batch).await?;
         }
         Ok(total_rows)
     }
@@ -100,7 +100,8 @@ mod tests {
             MetricSchema::default_metrics(),
         ));
 
-        let service = FlightIngestService::new(ingester);
+        let dispatcher = Arc::new(crate::api::ingest::IngestDispatcher::new(ingester, None));
+        let service = FlightIngestService::new(dispatcher);
         let batch = create_test_batch();
         let flight_data = batch_to_flight_data(&batch).unwrap();
         let rows = service

--- a/src/api/ingest/mod.rs
+++ b/src/api/ingest/mod.rs
@@ -1,5 +1,10 @@
 //! Ingestion API modules
 
+mod dispatcher;
 pub mod flight_ingest;
 pub mod otlp;
 pub mod prometheus;
+
+pub use dispatcher::{
+    handle_internal_arrow_ingest, IngestDispatcher, RoutingContext, ShardWriteRouter,
+};

--- a/src/api/ingest/otlp.rs
+++ b/src/api/ingest/otlp.rs
@@ -2,7 +2,7 @@
 //!
 //! Supports both gRPC and HTTP endpoints for OTLP metrics ingestion.
 
-use crate::ingester::Ingester;
+use crate::api::ingest::IngestDispatcher;
 use crate::schema::{METRIC_NAME_FIELD, TIMESTAMP_FIELD, VALUE_F64_FIELD};
 use crate::Result;
 
@@ -17,13 +17,13 @@ use std::sync::Arc;
 
 /// OTLP metrics receiver
 pub struct OtlpReceiver {
-    ingester: Arc<Ingester>,
+    dispatcher: Arc<IngestDispatcher>,
     _schema: Arc<Schema>,
 }
 
 impl OtlpReceiver {
     /// Create a new OTLP receiver
-    pub fn new(ingester: Arc<Ingester>) -> Self {
+    pub fn new(dispatcher: Arc<IngestDispatcher>) -> Self {
         // Build schema for converted metrics
         let schema = Arc::new(Schema::new(vec![
             Field::new(
@@ -37,7 +37,7 @@ impl OtlpReceiver {
         ]));
 
         Self {
-            ingester,
+            dispatcher,
             _schema: schema,
         }
     }
@@ -83,7 +83,7 @@ impl OtlpReceiver {
 
     /// Ingest metrics
     pub async fn ingest(&self, batch: RecordBatch) -> Result<()> {
-        self.ingester.write(batch).await
+        self.dispatcher.dispatch(batch).await
     }
 }
 

--- a/src/api/ingest/prometheus.rs
+++ b/src/api/ingest/prometheus.rs
@@ -45,7 +45,11 @@ pub async fn handle_remote_write(State(state): State<ApiState>, body: Bytes) -> 
     };
 
     // 4. Ingest
-    match state.ingester.write(batch).await {
+    let Some(dispatcher) = state.ingest_dispatcher else {
+        return StatusCode::SERVICE_UNAVAILABLE;
+    };
+
+    match dispatcher.dispatch(batch).await {
         Ok(_) => StatusCode::NO_CONTENT, // 204 = success
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -40,7 +40,8 @@ impl Default for ApiServerConfig {
 
 /// Build the HTTP API router
 pub fn build_http_router(
-    ingester: Arc<crate::ingester::Ingester>,
+    ingester: Option<Arc<crate::ingester::Ingester>>,
+    ingest_dispatcher: Option<Arc<crate::api::ingest::IngestDispatcher>>,
     query_node: Arc<crate::query::QueryNode>,
 ) -> Router {
     use axum::routing::{get, post};
@@ -51,7 +52,10 @@ pub fn build_http_router(
         .allow_methods(Any)
         .allow_headers(Any);
 
-    Router::new()
+    let ingest_enabled = ingest_dispatcher.is_some();
+    let internal_ingest_enabled = ingester.is_some();
+
+    let mut router = Router::new()
         // Health check
         .route("/health", get(health_check))
         .route("/ready", get(ready_check))
@@ -71,15 +75,26 @@ pub fn build_http_router(
         .route("/api/v1/series", get(query::prometheus_api::series))
         .route("/api/v1/series", post(query::prometheus_api::series_post))
 
-        // Prometheus Remote Write
-        .route("/api/v1/write", post(ingest::prometheus::handle_remote_write))
-
         // Streaming
-        .route("/api/v1/stream", get(query::streaming::websocket_handler))
+        .route("/api/v1/stream", get(query::streaming::websocket_handler));
 
-        // State
+    if ingest_enabled {
+        router = router.route(
+            "/api/v1/write",
+            post(ingest::prometheus::handle_remote_write),
+        );
+    }
+    if internal_ingest_enabled {
+        router = router.route(
+            "/internal/v1/ingest/arrow",
+            post(ingest::handle_internal_arrow_ingest),
+        );
+    }
+
+    router
         .with_state(ApiState {
             ingester,
+            ingest_dispatcher,
             query_node,
         })
         .layer(cors)
@@ -88,7 +103,8 @@ pub fn build_http_router(
 /// Shared API state
 #[derive(Clone)]
 pub struct ApiState {
-    pub ingester: Arc<crate::ingester::Ingester>,
+    pub ingester: Option<Arc<crate::ingester::Ingester>>,
+    pub ingest_dispatcher: Option<Arc<crate::api::ingest::IngestDispatcher>>,
     pub query_node: Arc<crate::query::QueryNode>,
 }
 

--- a/src/api/query/streaming.rs
+++ b/src/api/query/streaming.rs
@@ -87,7 +87,19 @@ async fn handle_connection(mut socket: WebSocket, state: ApiState) {
 
     // Stream live data if requested
     if request.live {
-        let mut rx = state.ingester.subscribe();
+        let Some(ingester) = state.ingester else {
+            let _ = socket
+                .send(Message::Text(
+                    serde_json::to_string(&StreamMessage {
+                        msg_type: "error".to_string(),
+                        data: serde_json::json!({ "error": "live ingest stream unavailable on this node" }),
+                    })
+                    .unwrap(),
+                ))
+                .await;
+            return;
+        };
+        let mut rx = ingester.subscribe();
 
         loop {
             tokio::select! {

--- a/src/bin/ingester.rs
+++ b/src/bin/ingester.rs
@@ -3,6 +3,10 @@
 //! Stateless ingester node that receives metrics and writes to object storage.
 
 use cardinalsin::api;
+use cardinalsin::api::ingest::{IngestDispatcher, RoutingContext};
+use cardinalsin::cluster::{
+    AssignmentStrategy, DistributedWriteRouter, NodeInfo, NodeRegistry, NodeType, ShardAssignment,
+};
 use cardinalsin::config::ComponentFactory;
 use cardinalsin::ingester::{Ingester, IngesterConfig, WalConfig, WalSyncMode};
 use cardinalsin::query::{QueryConfig, QueryNode};
@@ -45,6 +49,18 @@ struct Args {
     /// Tenant ID
     #[arg(long, env = "TENANT_ID", default_value = "default")]
     tenant_id: String,
+
+    /// Stable node identifier used for distributed shard routing
+    #[arg(long, env = "NODE_ID")]
+    node_id: Option<String>,
+
+    /// HTTP address other ingesters should use when forwarding shard batches
+    #[arg(long, env = "ADVERTISE_HTTP_ADDR")]
+    advertise_http_addr: Option<SocketAddr>,
+
+    /// Other ingester nodes in the cluster as `node-id=host:port`
+    #[arg(long, env = "INGESTER_PEERS", value_delimiter = ',')]
+    ingester_peers: Vec<String>,
 
     /// Flush interval in seconds
     #[arg(long, default_value = "300")]
@@ -133,6 +149,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let ingester = Arc::new(ingester);
 
+    let routing_context = build_routing_context(
+        args.node_id.clone(),
+        args.advertise_http_addr,
+        args.http_port,
+        &args.ingester_peers,
+        &args.tenant_id,
+    )
+    .await?;
+    let ingest_dispatcher = Arc::new(IngestDispatcher::new(ingester.clone(), routing_context));
+
     // Start flush timer
     let ingester_timer = ingester.clone();
     tokio::spawn(async move {
@@ -155,7 +181,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Build HTTP router
-    let router = api::build_http_router(ingester.clone(), query_node);
+    let router = api::build_http_router(
+        Some(ingester.clone()),
+        Some(ingest_dispatcher.clone()),
+        query_node,
+    );
 
     // Start HTTP server
     let addr = SocketAddr::from(([0, 0, 0, 0], args.http_port));
@@ -181,7 +211,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .await
             .map_err(|e| Error::Internal(format!("HTTP server error: {e}")))
     };
-    let grpc_server = api::grpc::run_ingester_grpc_server(grpc_addr, ingester, grpc_shutdown);
+    let grpc_server =
+        api::grpc::run_ingester_grpc_server(grpc_addr, ingest_dispatcher, grpc_shutdown);
     tokio::try_join!(http_server, grpc_server)?;
 
     info!("Ingester shutting down");
@@ -218,4 +249,59 @@ async fn wait_for_shutdown(mut shutdown: watch::Receiver<bool>) {
         return;
     }
     let _ = shutdown.changed().await;
+}
+
+async fn build_routing_context(
+    node_id: Option<String>,
+    advertise_http_addr: Option<SocketAddr>,
+    http_port: u16,
+    ingester_peers: &[String],
+    tenant_id: &str,
+) -> Result<Option<RoutingContext>, Box<dyn std::error::Error>> {
+    if node_id.is_none() && ingester_peers.is_empty() {
+        return Ok(None);
+    }
+
+    let local_node_id = node_id.unwrap_or_else(|| format!("ingester-{}", http_port));
+    let local_addr =
+        advertise_http_addr.unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], http_port)));
+
+    let nodes = Arc::new(NodeRegistry::new(30));
+    nodes
+        .register_node(NodeInfo::new(
+            local_node_id.clone(),
+            local_addr,
+            NodeType::Ingester,
+        ))
+        .await;
+
+    for peer in ingester_peers {
+        nodes.register_node(parse_ingester_peer(peer)?).await;
+    }
+
+    let assignments = Arc::new(ShardAssignment::new(
+        nodes.clone(),
+        AssignmentStrategy::ConsistentHash,
+    ));
+    let router = Arc::new(DistributedWriteRouter::new(assignments, nodes));
+
+    Ok(Some(RoutingContext::new(
+        router,
+        local_node_id,
+        tenant_id.to_string(),
+    )))
+}
+
+fn parse_ingester_peer(spec: &str) -> Result<NodeInfo, Box<dyn std::error::Error>> {
+    let (node_id, addr) = spec.split_once('=').ok_or_else(|| {
+        format!(
+            "invalid ingester peer '{}': expected node-id=host:port",
+            spec
+        )
+    })?;
+    Ok(NodeInfo::new(
+        node_id.to_string(),
+        addr.parse()?,
+        NodeType::Ingester,
+    ))
 }

--- a/src/bin/query.rs
+++ b/src/bin/query.rs
@@ -4,9 +4,7 @@
 
 use cardinalsin::api;
 use cardinalsin::config::ComponentFactory;
-use cardinalsin::ingester::{Ingester, IngesterConfig};
 use cardinalsin::query::{QueryConfig, QueryNode};
-use cardinalsin::schema::MetricSchema;
 use cardinalsin::telemetry::Telemetry;
 use cardinalsin::Error;
 
@@ -103,17 +101,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .await?,
     );
 
-    // Create a dummy ingester for the API (in production, query nodes don't ingest)
-    let ingester = Arc::new(Ingester::new(
-        IngesterConfig::default(),
-        object_store,
-        metadata,
-        storage_config,
-        MetricSchema::default_metrics(),
-    ));
-
     // Build HTTP router
-    let router = api::build_http_router(ingester, query_node.clone());
+    let router = api::build_http_router(None, None, query_node.clone());
 
     // Start HTTP server
     let addr = SocketAddr::from(([0, 0, 0, 0], args.http_port));

--- a/src/cluster/write_router.rs
+++ b/src/cluster/write_router.rs
@@ -5,8 +5,11 @@
 
 use super::node_registry::{NodeInfo, NodeRegistry};
 use super::shard_assignment::ShardAssignment;
+use crate::api::ingest::ShardWriteRouter;
+use crate::ingester::encode_record_batch_ipc;
 use crate::Result;
 use arrow_array::RecordBatch;
+use async_trait::async_trait;
 use std::sync::Arc;
 use tracing::{debug, warn};
 
@@ -16,66 +19,33 @@ pub struct DistributedWriteRouter {
     assignments: Arc<ShardAssignment>,
     /// Node registry
     nodes: Arc<NodeRegistry>,
+    /// Shared HTTP client for remote forwarding
+    http_client: reqwest::Client,
 }
 
 impl DistributedWriteRouter {
     /// Create a new distributed write router
     pub fn new(assignments: Arc<ShardAssignment>, nodes: Arc<NodeRegistry>) -> Self {
-        Self { assignments, nodes }
-    }
-
-    /// Route a write to the appropriate ingester node
-    ///
-    /// If the write is for a shard owned by this node, returns None (handle locally).
-    /// If the write is for a shard owned by another node, returns the target node info.
-    pub async fn route_write(&self, shard_id: &str) -> Result<Option<NodeInfo>> {
-        // Get assigned node for this shard
-        let node_id = self.assignments.assign_shard(shard_id).await?;
-
-        // Get node info
-        if let Some(node) = self.nodes.get_node(&node_id).await {
-            if node.can_accept_writes() {
-                debug!("Routing write for shard {} to node {}", shard_id, node_id);
-                return Ok(Some(node));
-            } else {
-                warn!(
-                    "Assigned node {} cannot accept writes, reassigning",
-                    node_id
-                );
-                self.assignments.unassign_shard(shard_id).await;
-                // Retry assignment (boxed to avoid infinite recursion)
-                return Box::pin(self.route_write(shard_id)).await;
-            }
+        Self {
+            assignments,
+            nodes,
+            http_client: reqwest::Client::new(),
         }
-
-        Err(crate::Error::Internal(format!(
-            "No healthy node available for shard {}",
-            shard_id
-        )))
     }
 
-    /// Forward a write request to another ingester node
-    ///
-    /// This is called when the current node receives a write for a shard
-    /// it doesn't own. The write is forwarded to the owning node via HTTP.
-    ///
-    /// TODO: Implement actual HTTP forwarding with Arrow IPC serialization.
-    /// This requires adding reqwest dependency and implementing batch serialization.
+    /// Route a write to the appropriate ingester node.
+    pub async fn route_write(&self, shard_id: &str) -> Result<Option<NodeInfo>> {
+        <Self as ShardWriteRouter>::route_write(self, shard_id).await
+    }
+
+    /// Forward a shard-local Arrow batch to another ingester node.
     pub async fn forward_write(
         &self,
         target_node: &NodeInfo,
-        _batch: &RecordBatch,
-        _tenant_id: &str,
+        batch: &RecordBatch,
+        tenant_id: &str,
     ) -> Result<()> {
-        let url = format!("http://{}/api/v1/write", target_node.addr);
-
-        // Placeholder implementation
-        debug!(
-            "Forwarding write to node {} at {} (TODO: implement HTTP forwarding)",
-            target_node.id, url
-        );
-
-        Ok(())
+        <Self as ShardWriteRouter>::forward_write(self, target_node, batch, tenant_id).await
     }
 
     /// Get routing statistics
@@ -108,6 +78,68 @@ impl DistributedWriteRouter {
             avg_shards_per_node,
             imbalance,
         }
+    }
+}
+
+#[async_trait]
+impl ShardWriteRouter for DistributedWriteRouter {
+    /// Route a write to the appropriate ingester node.
+    async fn route_write(&self, shard_id: &str) -> Result<Option<NodeInfo>> {
+        let node_id = self.assignments.assign_shard(shard_id).await?;
+
+        if let Some(node) = self.nodes.get_node(&node_id).await {
+            if node.can_accept_writes() {
+                debug!("Routing write for shard {} to node {}", shard_id, node_id);
+                return Ok(Some(node));
+            }
+
+            warn!(
+                "Assigned node {} cannot accept writes, reassigning",
+                node_id
+            );
+            self.assignments.unassign_shard(shard_id).await;
+            return Box::pin(self.route_write(shard_id)).await;
+        }
+
+        Err(crate::Error::Internal(format!(
+            "No healthy node available for shard {}",
+            shard_id
+        )))
+    }
+
+    /// Forward a shard-local Arrow batch to another ingester node.
+    async fn forward_write(
+        &self,
+        target_node: &NodeInfo,
+        batch: &RecordBatch,
+        tenant_id: &str,
+    ) -> Result<()> {
+        let url = format!("http://{}/internal/v1/ingest/arrow", target_node.addr);
+        let payload = encode_record_batch_ipc(batch)?;
+        let response = self
+            .http_client
+            .post(&url)
+            .header("content-type", "application/vnd.apache.arrow.stream")
+            .header("x-cardinalsin-tenant-id", tenant_id)
+            .body(payload)
+            .send()
+            .await
+            .map_err(|e| {
+                crate::Error::Internal(format!(
+                    "Failed to forward shard write to {}: {}",
+                    target_node.id, e
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(crate::Error::Internal(format!(
+                "Remote ingester {} rejected forwarded shard write with status {}",
+                target_node.id,
+                response.status()
+            )));
+        }
+
+        Ok(())
     }
 }
 

--- a/src/ingester/arrow_ipc.rs
+++ b/src/ingester/arrow_ipc.rs
@@ -1,0 +1,63 @@
+use crate::{Error, Result};
+use arrow_array::RecordBatch;
+use arrow_ipc::reader::StreamReader;
+use arrow_ipc::writer::StreamWriter;
+use std::io::Cursor;
+
+/// Encode a single RecordBatch as Arrow IPC stream bytes.
+pub fn encode_record_batch_ipc(batch: &RecordBatch) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut writer = StreamWriter::try_new(&mut bytes, &batch.schema())?;
+    writer.write(batch)?;
+    writer.finish()?;
+    Ok(bytes)
+}
+
+/// Decode a single RecordBatch from Arrow IPC stream bytes.
+pub fn decode_record_batch_ipc(bytes: &[u8]) -> Result<RecordBatch> {
+    let mut reader = StreamReader::try_new(Cursor::new(bytes.to_vec()), None)?;
+    let batch = reader.next().transpose()?.ok_or_else(|| {
+        Error::InvalidSchema("Arrow IPC payload contained no record batches".into())
+    })?;
+
+    if reader.next().transpose()?.is_some() {
+        return Err(Error::InvalidSchema(
+            "Arrow IPC payload must contain exactly one record batch".into(),
+        ));
+    }
+
+    Ok(batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Float64Array, Int64Array};
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn make_batch() -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("timestamp", DataType::Int64, false),
+            Field::new("value", DataType::Float64, false),
+        ]));
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(Float64Array::from(vec![1.0, 2.0, 3.0])),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn round_trips_single_record_batch() {
+        let batch = make_batch();
+        let encoded = encode_record_batch_ipc(&batch).unwrap();
+        let decoded = decode_record_batch_ipc(&encoded).unwrap();
+        assert_eq!(decoded.num_rows(), batch.num_rows());
+        assert_eq!(decoded.schema(), batch.schema());
+    }
+}

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -7,6 +7,7 @@
 //! - Broadcasting new data to streaming query subscribers
 //! - Tracking shard metrics for hot shard detection
 
+mod arrow_ipc;
 mod broadcast;
 mod buffer;
 mod parquet_writer;
@@ -14,6 +15,7 @@ mod telemetry;
 mod topic_broadcast;
 mod wal;
 
+pub use arrow_ipc::{decode_record_batch_ipc, encode_record_batch_ipc};
 pub use broadcast::BroadcastChannel;
 pub use buffer::WriteBuffer;
 pub use parquet_writer::ParquetWriter;
@@ -446,6 +448,14 @@ impl Ingester {
     fn should_flush(&self, buffer: &WriteBuffer) -> bool {
         buffer.row_count() >= self.config.flush_row_count
             || buffer.size_bytes() >= self.config.flush_size_bytes
+    }
+
+    /// Partition a batch into shard-local sub-batches for distributed routing.
+    pub async fn partition_batch_for_routing(
+        &self,
+        batch: &RecordBatch,
+    ) -> Result<HashMap<String, RecordBatch>> {
+        self.partition_batch_by_shard(batch).await
     }
 
     async fn total_buffer_rows(&self) -> usize {

--- a/tests/distributed_ingest_routing_tests.rs
+++ b/tests/distributed_ingest_routing_tests.rs
@@ -165,7 +165,7 @@ async fn dispatcher_routes_local_and_remote_shards_separately() {
         1,
         "only the local shard should be ingested locally"
     );
-    assert_eq!(chunks[0].shard_id.as_deref(), Some(shard_a.as_str()));
+    assert_eq!(chunks[0].shard_id.as_str(), shard_a.as_str());
 
     let forwarded = router.forwarded.lock().await.clone();
     assert_eq!(

--- a/tests/distributed_ingest_routing_tests.rs
+++ b/tests/distributed_ingest_routing_tests.rs
@@ -1,0 +1,230 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use axum::Router;
+use cardinalsin::api;
+use cardinalsin::api::ingest::{IngestDispatcher, RoutingContext, ShardWriteRouter};
+use cardinalsin::cluster::{
+    AssignmentStrategy, DistributedWriteRouter, NodeInfo, NodeRegistry, NodeType, ShardAssignment,
+};
+use cardinalsin::ingester::{Ingester, IngesterConfig};
+use cardinalsin::metadata::{LocalMetadataClient, MetadataClient};
+use cardinalsin::query::{QueryConfig, QueryNode};
+use cardinalsin::schema::MetricSchema;
+use cardinalsin::sharding::{HotShardConfig, ShardKey};
+use cardinalsin::{CloudProvider, Result, StorageConfig};
+use object_store::memory::InMemory;
+use tokio::net::TcpListener;
+use tokio::sync::Mutex;
+
+use arrow_array::{Float64Array, Int64Array, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema};
+
+fn make_batch(rows: &[(i64, &str)]) -> RecordBatch {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("timestamp", DataType::Int64, false),
+        Field::new("metric_name", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, false),
+    ]));
+
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int64Array::from(
+                rows.iter().map(|(ts, _)| *ts).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                rows.iter().map(|(_, metric)| *metric).collect::<Vec<_>>(),
+            )),
+            Arc::new(Float64Array::from(
+                (0..rows.len()).map(|idx| idx as f64).collect::<Vec<_>>(),
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+fn make_ingester(
+    metadata: Arc<LocalMetadataClient>,
+    tenant_id: u32,
+    flush_row_count: usize,
+) -> Arc<Ingester> {
+    let config = IngesterConfig {
+        flush_interval: Duration::from_secs(3600),
+        flush_row_count,
+        flush_size_bytes: usize::MAX,
+        ..Default::default()
+    };
+    let store = Arc::new(InMemory::new());
+    let storage_config = StorageConfig {
+        provider: CloudProvider::Memory,
+        container: "test-bucket".to_string(),
+        tenant_id: "tenant-a".to_string(),
+    };
+    let metadata_client: Arc<dyn MetadataClient> = metadata;
+    Arc::new(Ingester::with_shard_config(
+        config,
+        store,
+        metadata_client,
+        storage_config,
+        MetricSchema::default_metrics(),
+        HotShardConfig::default(),
+        tenant_id,
+    ))
+}
+
+struct FakeRouter {
+    routes: HashMap<String, Option<NodeInfo>>,
+    forwarded: Mutex<Vec<(String, usize, String)>>,
+}
+
+#[async_trait]
+impl ShardWriteRouter for FakeRouter {
+    async fn route_write(&self, shard_id: &str) -> Result<Option<NodeInfo>> {
+        Ok(self.routes.get(shard_id).cloned().flatten())
+    }
+
+    async fn forward_write(
+        &self,
+        target_node: &NodeInfo,
+        batch: &RecordBatch,
+        tenant_id: &str,
+    ) -> Result<()> {
+        self.forwarded.lock().await.push((
+            target_node.id.clone(),
+            batch.num_rows(),
+            tenant_id.to_string(),
+        ));
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn dispatcher_preserves_local_behavior_when_routing_disabled() {
+    let metadata = Arc::new(LocalMetadataClient::new());
+    let ingester = make_ingester(metadata.clone(), 11, 1);
+    let dispatcher = IngestDispatcher::new(ingester, None);
+
+    let ts = 1_700_000_000_000_000_000i64;
+    dispatcher
+        .dispatch(make_batch(&[(ts, "cpu_usage"), (ts, "cpu_usage")]))
+        .await
+        .unwrap();
+
+    let chunks = metadata.list_chunks().await.unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].row_count, 2);
+}
+
+#[tokio::test]
+async fn dispatcher_routes_local_and_remote_shards_separately() {
+    let metadata = Arc::new(LocalMetadataClient::new());
+    let ingester = make_ingester(metadata.clone(), 11, 1);
+
+    let ts_a = 1_700_000_000_000_000_000i64;
+    let ts_b = ts_a + 5 * 60 * 1_000_000_000i64;
+    let shard_a = ShardKey::new(11, "cpu_usage", ts_a).shard_id();
+    let shard_b = ShardKey::new(11, "cpu_usage", ts_b).shard_id();
+
+    let local_node = NodeInfo::new(
+        "node-local".to_string(),
+        "127.0.0.1:19090".parse().unwrap(),
+        NodeType::Ingester,
+    );
+    let remote_node = NodeInfo::new(
+        "node-remote".to_string(),
+        "127.0.0.1:19091".parse().unwrap(),
+        NodeType::Ingester,
+    );
+    let router = Arc::new(FakeRouter {
+        routes: HashMap::from([
+            (shard_a.clone(), Some(local_node)),
+            (shard_b.clone(), Some(remote_node.clone())),
+        ]),
+        forwarded: Mutex::new(Vec::new()),
+    });
+    let dispatcher = IngestDispatcher::new(
+        ingester,
+        Some(RoutingContext::new(
+            router.clone(),
+            "node-local".to_string(),
+            "tenant-a".to_string(),
+        )),
+    );
+
+    dispatcher
+        .dispatch(make_batch(&[(ts_a, "cpu_usage"), (ts_b, "cpu_usage")]))
+        .await
+        .unwrap();
+
+    let chunks = metadata.list_chunks().await.unwrap();
+    assert_eq!(
+        chunks.len(),
+        1,
+        "only the local shard should be ingested locally"
+    );
+    assert_eq!(chunks[0].shard_id.as_deref(), Some(shard_a.as_str()));
+
+    let forwarded = router.forwarded.lock().await.clone();
+    assert_eq!(
+        forwarded,
+        vec![("node-remote".to_string(), 1, "tenant-a".to_string())]
+    );
+}
+
+async fn make_query_node() -> Arc<QueryNode> {
+    let store = Arc::new(InMemory::new());
+    let metadata: Arc<dyn MetadataClient> = Arc::new(LocalMetadataClient::new());
+    let storage_config = StorageConfig {
+        provider: CloudProvider::Memory,
+        container: "test-bucket".to_string(),
+        tenant_id: "tenant-a".to_string(),
+    };
+    Arc::new(
+        QueryNode::new(QueryConfig::default(), store, metadata, storage_config)
+            .await
+            .unwrap(),
+    )
+}
+
+#[tokio::test]
+async fn distributed_write_router_forwards_arrow_batches_to_internal_endpoint() {
+    let remote_metadata = Arc::new(LocalMetadataClient::new());
+    let remote_ingester = make_ingester(remote_metadata.clone(), 3, 1);
+    let query_node = make_query_node().await;
+    let dispatcher = Arc::new(IngestDispatcher::new(remote_ingester.clone(), None));
+    let router: Router =
+        api::build_http_router(Some(remote_ingester), Some(dispatcher), query_node);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+
+    let nodes = Arc::new(NodeRegistry::new(30));
+    let assignments = Arc::new(ShardAssignment::new(
+        nodes.clone(),
+        AssignmentStrategy::ConsistentHash,
+    ));
+    let write_router = DistributedWriteRouter::new(assignments, nodes);
+    let target_node = NodeInfo::new("node-remote".to_string(), addr, NodeType::Ingester);
+
+    let ts = 1_700_000_000_000_000_000i64;
+    write_router
+        .forward_write(
+            &target_node,
+            &make_batch(&[(ts, "cpu_usage"), (ts, "cpu_usage")]),
+            "tenant-a",
+        )
+        .await
+        .unwrap();
+
+    let chunks = remote_metadata.list_chunks().await.unwrap();
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].row_count, 2);
+
+    server.abort();
+}


### PR DESCRIPTION
## Summary
- add a shared ingest dispatcher for Prometheus, OTLP, and Flight ingestion paths
- route shard-local batches through the distributed write router and forward remote shards over an internal Arrow IPC endpoint
- wire optional cluster routing into the ingester binary and stop exposing write endpoints on query nodes

## Issues
- closes #173

## Testing
- cargo test -q --test distributed_ingest_routing_tests
- cargo test -q -- --skip test_full_split_execution