### PR TITLE
ci(e2e): build release binaries natively; drop broken Docker layer cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Exclude everything by default
+**
+
+# Allow only the pre-built binaries needed by Dockerfile.prebuilt
+!target/release/cardinalsin-ingester
+!target/release/cardinalsin-query
+!target/release/cardinalsin-compactor
+
+# Allow source files needed by the standard Dockerfile
+!src/
+!tests/
+!benches/
+!Cargo.toml
+!Cargo.lock
+!deploy/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,23 +60,17 @@ jobs:
         with:
           toolchain: 1.93.0
 
-      - name: Cache Rust artifacts
+      - name: Cache Rust artifacts (release)
         uses: Swatinem/rust-cache@v2
         with:
-          key: e2e-${{ hashFiles('**/Cargo.lock') }}
+          key: e2e-release-${{ hashFiles('**/Cargo.lock') }}
+          cache-on-failure: true
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Build release binaries
+        run: cargo build --release --bin cardinalsin-ingester --bin cardinalsin-query --bin cardinalsin-compactor
 
-      - name: Build cardinalsin image (with layer cache)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: deploy/Dockerfile
-          load: true
-          tags: cardinalsin:ci
-          cache-from: type=gha,scope=cardinalsin-image
-          cache-to: type=gha,mode=max,scope=cardinalsin-image
+      - name: Package binaries into Docker image
+        run: docker build -f deploy/Dockerfile.prebuilt -t cardinalsin:ci .
 
       - name: Start docker-compose stack
         run: CARDINALSIN_IMAGE=cardinalsin:ci docker compose -f deploy/docker-compose.yml up -d

--- a/deploy/Dockerfile.prebuilt
+++ b/deploy/Dockerfile.prebuilt
@@ -1,0 +1,22 @@
+ARG DEBIAN_RELEASE=bookworm
+
+# Packages pre-built binaries from target/release/ into the runtime image.
+# Used by CI: cargo build --release --bins is run natively (with Swatinem cache),
+# then this Dockerfile copies the binaries in seconds.
+FROM debian:${DEBIAN_RELEASE}-slim
+
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY target/release/cardinalsin-ingester /usr/local/bin/
+COPY target/release/cardinalsin-query /usr/local/bin/
+COPY target/release/cardinalsin-compactor /usr/local/bin/
+
+RUN useradd -m -s /bin/bash cardinalsin
+USER cardinalsin
+
+CMD ["cardinalsin-query"]

--- a/deploy/Dockerfile.prebuilt
+++ b/deploy/Dockerfile.prebuilt
@@ -19,4 +19,5 @@ COPY target/release/cardinalsin-compactor /usr/local/bin/
 RUN useradd -m -s /bin/bash cardinalsin
 USER cardinalsin
 
-CMD ["cardinalsin-query"]
+# No default CMD — this image runs all three services.
+# The command is always specified by docker-compose (command: ["cardinalsin-ingester"] etc.)


### PR DESCRIPTION
## Problem

The Docker GHA layer cache (`type=gha`) does not work across branches. GitHub scopes caches per-branch, so every PR branch is a cold miss. Two consecutive runs confirmed it:

| Run | Branch | Build time |
|-----|--------|-----------|
| 22886654889 | feat/shard-aware-data-path | 1081s (18 min) |
| 22882983257 | fix/compactor-heterogeneous-schema-panic | 1174s (19.5 min) |

Both are full rebuilds despite the cache being "configured". The first run seeded the cache on `ci/speed-up-e2e-docker-cache` but that's inaccessible from other branches.

## Fix

Drop `docker/build-push-action` entirely. Instead:

1. **`cargo build --release --bins`** — Swatinem/rust-cache is branch-agnostic (it uses the GHA cache API directly and restores from any branch), proven reliable across the entire `test` job
2. **`docker build -f deploy/Dockerfile.prebuilt`** — new slim Dockerfile that just `COPY`s the pre-built binaries into a `debian:bookworm-slim` base (~10s)

## Expected timing

| Scenario | Before | After |
|----------|--------|-------|
| `Cargo.lock` unchanged (most PRs) | ~18 min | ~30s |
| Only `src/` changed | ~18 min | ~2-4 min |
| `Cargo.lock` changed | ~18 min | ~17 min (then cached) |
| Docker image build | N/A | ~10s |

## Test plan
- [ ] E2E job on this PR: first run primes Swatinem release cache (~17 min)
- [ ] E2E job on the next PR: Swatinem hits cache, build is fast

🤖 Generated with [Claude Code](https://claude.com/claude-code)