### PR TITLE
feat: shard-aware data paths — hash-based routing, per-shard buffers, query pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,6 +841,7 @@ dependencies = [
  "tower-http 0.5.2",
  "tracing",
  "tracing-subscriber",
+ "twox-hash 2.1.2",
  "url",
  "uuid",
  "wiremock",
@@ -5168,6 +5169,9 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand 0.9.2",
+]
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ dotenvy = "0.15"
 humantime = "2"
 reqwest = { version = "0.12", features = ["json"] }
 crc32fast = "1.5.0"
+twox-hash = "2"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }

--- a/src/compactor/mod.rs
+++ b/src/compactor/mod.rs
@@ -318,39 +318,41 @@ impl Compactor {
 
                     // Spawn the split process in the background so it doesn't block the main loop
                     tokio::spawn(async move {
-                        let shard_metadata =
-                            match metadata_client.get_shard_metadata(&shard_id.to_string()).await {
-                                Ok(Some(meta)) => meta,
-                                Ok(None) => {
-                                    error!("Cannot split shard {}: metadata not found.", shard_id);
-                                    counter!(
-                                        "cardinalsin_split_actions_total",
-                                        "service" => crate::telemetry::service(),
-                                        "run_id" => crate::telemetry::run_id(),
-                                        "tenant" => crate::telemetry::tenant(),
-                                        "action" => "split",
-                                        "result" => "error"
-                                    )
-                                    .increment(1);
-                                    return;
-                                }
-                                Err(e) => {
-                                    error!(
-                                        "Cannot split shard {}: failed to get metadata: {}",
-                                        shard_id, e
-                                    );
-                                    counter!(
-                                        "cardinalsin_split_actions_total",
-                                        "service" => crate::telemetry::service(),
-                                        "run_id" => crate::telemetry::run_id(),
-                                        "tenant" => crate::telemetry::tenant(),
-                                        "action" => "split",
-                                        "result" => "error"
-                                    )
-                                    .increment(1);
-                                    return;
-                                }
-                            };
+                        let shard_metadata = match metadata_client
+                            .get_shard_metadata(&shard_id.to_string())
+                            .await
+                        {
+                            Ok(Some(meta)) => meta,
+                            Ok(None) => {
+                                error!("Cannot split shard {}: metadata not found.", shard_id);
+                                counter!(
+                                    "cardinalsin_split_actions_total",
+                                    "service" => crate::telemetry::service(),
+                                    "run_id" => crate::telemetry::run_id(),
+                                    "tenant" => crate::telemetry::tenant(),
+                                    "action" => "split",
+                                    "result" => "error"
+                                )
+                                .increment(1);
+                                return;
+                            }
+                            Err(e) => {
+                                error!(
+                                    "Cannot split shard {}: failed to get metadata: {}",
+                                    shard_id, e
+                                );
+                                counter!(
+                                    "cardinalsin_split_actions_total",
+                                    "service" => crate::telemetry::service(),
+                                    "run_id" => crate::telemetry::run_id(),
+                                    "tenant" => crate::telemetry::tenant(),
+                                    "action" => "split",
+                                    "result" => "error"
+                                )
+                                .increment(1);
+                                return;
+                            }
+                        };
 
                         // Ensure we don't try to split a shard that's already splitting
                         if !shard_metadata.is_active() {

--- a/src/compactor/mod.rs
+++ b/src/compactor/mod.rs
@@ -319,7 +319,7 @@ impl Compactor {
                     // Spawn the split process in the background so it doesn't block the main loop
                     tokio::spawn(async move {
                         let shard_metadata =
-                            match metadata_client.get_shard_metadata(&shard_id).await {
+                            match metadata_client.get_shard_metadata(&shard_id.to_string()).await {
                                 Ok(Some(meta)) => meta,
                                 Ok(None) => {
                                     error!("Cannot split shard {}: metadata not found.", shard_id);

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -380,7 +380,11 @@ impl Ingester {
 
     /// Write with split awareness (dual-write to old and new shards).
     /// WAL has already been appended by the caller.
-    async fn write_with_split_awareness(&self, batch: RecordBatch, shard_id: ShardId) -> Result<()> {
+    async fn write_with_split_awareness(
+        &self,
+        batch: RecordBatch,
+        shard_id: ShardId,
+    ) -> Result<()> {
         let split_state = self
             .metadata
             .get_split_state(&shard_id.to_string())
@@ -468,11 +472,10 @@ impl Ingester {
     ) -> Result<(RecordBatch, RecordBatch)> {
         use arrow_array::cast::AsArray;
 
-        let split_hash = u32::from_be_bytes(
-            split_point
-                .try_into()
-                .map_err(|_| Error::Internal("Invalid split point (expected 4 bytes)".to_string()))?,
-        );
+        let split_hash =
+            u32::from_be_bytes(split_point.try_into().map_err(|_| {
+                Error::Internal("Invalid split point (expected 4 bytes)".to_string())
+            })?);
 
         let metric_col = batch
             .column_by_name("metric_name")

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -25,7 +25,7 @@ pub use wal::{load_flushed_seq, persist_flushed_seq, WalConfig, WalSyncMode, Wri
 use crate::clock::BoundedClock;
 use crate::metadata::MetadataClient;
 use crate::schema::MetricSchema;
-use crate::sharding::{HotShardConfig, ShardKey, ShardMonitor};
+use crate::sharding::{HotShardConfig, ShardId, ShardMonitor};
 use crate::{Error, Result, StorageConfig};
 
 use arrow_array::RecordBatch;
@@ -305,14 +305,14 @@ impl Ingester {
         let shard_id = self.compute_shard_id(&batch);
         let result = async {
             // Check if shard is being split - if so, use dual-write
-            if let Some(split_state) = self.metadata.get_split_state(&shard_id).await? {
+            if let Some(split_state) = self.metadata.get_split_state(&shard_id.to_string()).await? {
                 use crate::sharding::SplitPhase;
                 if matches!(
                     split_state.phase,
                     SplitPhase::DualWrite | SplitPhase::Backfill
                 ) {
                     info!("Shard {} is splitting, enabling dual-write mode", shard_id);
-                    return self.write_with_split_awareness(batch, &shard_id).await;
+                    return self.write_with_split_awareness(batch, shard_id).await;
                 }
             }
 
@@ -355,10 +355,10 @@ impl Ingester {
     }
 
     /// Write with split awareness (dual-write to old and new shards)
-    async fn write_with_split_awareness(&self, batch: RecordBatch, shard_id: &str) -> Result<()> {
+    async fn write_with_split_awareness(&self, batch: RecordBatch, shard_id: ShardId) -> Result<()> {
         let split_state = self
             .metadata
-            .get_split_state(shard_id)
+            .get_split_state(&shard_id.to_string())
             .await?
             .ok_or_else(|| Error::Internal("Split state disappeared".to_string()))?;
 
@@ -445,6 +445,7 @@ impl Ingester {
             max_timestamp: self.extract_max_timestamp(batch)?,
             row_count: batch.num_rows() as u64,
             size_bytes: parquet_size,
+            shard_id: 0,
         };
         self.metadata.register_chunk(&path, &chunk_metadata).await?;
 
@@ -500,8 +501,7 @@ impl Ingester {
     }
 
     /// Compute shard ID for a batch based on tenant and metric
-    fn compute_shard_id(&self, batch: &RecordBatch) -> String {
-        // Extract metric name if available for shard key computation
+    fn compute_shard_id(&self, batch: &RecordBatch) -> ShardId {
         let metric_name = if let Some(col) = batch.column_by_name("metric_name") {
             use arrow_array::cast::AsArray;
             if let Some(arr) = col.as_string_opt::<i32>() {
@@ -513,27 +513,9 @@ impl Ingester {
             "unknown".to_string()
         };
 
-        // Extract timestamp for time-based sharding
-        let timestamp = if let Some(col) = batch.column_by_name("timestamp") {
-            use arrow_array::cast::AsArray;
-            if let Some(arr) = col.as_primitive_opt::<arrow_array::types::TimestampNanosecondType>()
-            {
-                arr.value(0)
-            } else if let Some(arr) = col.as_primitive_opt::<arrow_array::types::Int64Type>() {
-                arr.value(0)
-            } else {
-                self.clock.now_nanos()
-            }
-        } else {
-            self.clock.now_nanos()
-        };
-
-        // Create shard key and convert to shard ID
-        let shard_key = ShardKey::new(self.default_tenant_id, &metric_name, timestamp);
-        format!(
-            "shard-{:x}",
-            u64::from_be_bytes(shard_key.to_bytes()[0..8].try_into().unwrap_or([0u8; 8]))
-        )
+        let hash = crate::sharding::hash_metric_name(&metric_name);
+        // For now, return hash as u32 (shard resolution will use cached ranges later)
+        hash as ShardId
     }
 
     /// Extract all unique metric names from a batch for topic routing
@@ -658,12 +640,14 @@ impl Ingester {
             .await?;
 
         // Register in metadata store
+        let shard_id = self.compute_shard_id(&combined);
         let chunk_metadata = ChunkMetadata {
             path: path.clone(),
             min_timestamp: self.extract_min_timestamp(&combined)?,
             max_timestamp: self.extract_max_timestamp(&combined)?,
             row_count: combined.num_rows() as u64,
             size_bytes: parquet_size,
+            shard_id,
         };
         self.metadata.register_chunk(&path, &chunk_metadata).await?;
 
@@ -673,12 +657,11 @@ impl Ingester {
         }
 
         // Broadcast to topic-aware streaming query subscribers
-        let shard_id = self.compute_shard_id(&combined);
         let metrics = self.extract_metrics(&combined);
         let topic_batch = TopicBatch {
             batch: combined,
             metadata: BatchMetadata {
-                shard_id,
+                shard_id: shard_id.to_string(),
                 tenant_id: self.default_tenant_id,
                 metrics,
             },
@@ -839,6 +822,8 @@ pub struct ChunkMetadata {
     pub max_timestamp: i64,
     pub row_count: u64,
     pub size_bytes: u64,
+    #[serde(default)]
+    pub shard_id: crate::sharding::ShardId,
 }
 
 /// Buffer statistics

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -457,45 +457,40 @@ impl Ingester {
         Ok(())
     }
 
-    /// Split a batch by key range (based on timestamp split point)
+    /// Split a batch by metric hash against the split point (u32 hash midpoint).
+    ///
+    /// Rows whose `hash_metric_name(metric_name)` falls below the split point
+    /// go to batch_a (left child), the rest to batch_b (right child).
     fn split_batch_by_key(
         &self,
         batch: &RecordBatch,
         split_point: &[u8],
     ) -> Result<(RecordBatch, RecordBatch)> {
         use arrow_array::cast::AsArray;
-        use arrow_array::types::Int64Type;
 
-        // Extract timestamp column (our shard key is based on time)
-        let ts_column = batch
-            .column_by_name("timestamp")
-            .ok_or_else(|| Error::InvalidSchema("Missing timestamp column".into()))?;
+        let split_hash = u32::from_be_bytes(
+            split_point
+                .try_into()
+                .map_err(|_| Error::Internal("Invalid split point (expected 4 bytes)".to_string()))?,
+        );
 
-        let ts_array = ts_column
-            .as_primitive_opt::<Int64Type>()
-            .ok_or_else(|| Error::InvalidSchema("Timestamp not Int64".into()))?;
+        let metric_col = batch
+            .column_by_name("metric_name")
+            .and_then(|c| c.as_string_opt::<i32>());
 
-        // Build selection indices
         let mut indices_a = Vec::new();
         let mut indices_b = Vec::new();
 
-        // Convert split point to timestamp
-        let split_ts = i64::from_be_bytes(
-            split_point
-                .try_into()
-                .map_err(|_| Error::Internal("Invalid split point".to_string()))?,
-        );
-
         for i in 0..batch.num_rows() {
-            let ts = ts_array.value(i);
-            if ts < split_ts {
+            let metric_name = metric_col.map(|c| c.value(i)).unwrap_or("unknown");
+            let hash = hash_metric_name(metric_name) as u32;
+            if hash < split_hash {
                 indices_a.push(i as u32);
             } else {
                 indices_b.push(i as u32);
             }
         }
 
-        // Use Arrow take kernel to extract rows
         let indices_a_array = arrow::array::UInt32Array::from(indices_a);
         let indices_b_array = arrow::array::UInt32Array::from(indices_b);
 

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -626,9 +626,7 @@ impl Ingester {
                 .ok_or_else(|| Error::Internal("Missing pending batch".to_string()))?;
 
             // Ensure shard buffer exists
-            if !buffers.contains_key(&shard_id) {
-                buffers.insert(shard_id, WriteBuffer::new());
-            }
+            buffers.entry(shard_id).or_insert_with(WriteBuffer::new);
 
             // Check schema compatibility
             let schema_ok = buffers.get(&shard_id).unwrap().schema_compatible(incoming);

--- a/src/ingester/mod.rs
+++ b/src/ingester/mod.rs
@@ -25,11 +25,14 @@ pub use wal::{load_flushed_seq, persist_flushed_seq, WalConfig, WalSyncMode, Wri
 use crate::clock::BoundedClock;
 use crate::metadata::MetadataClient;
 use crate::schema::MetricSchema;
-use crate::sharding::{HotShardConfig, ShardId, ShardMonitor};
+use crate::sharding::{
+    find_shard_for_hash, hash_metric_name, HotShardConfig, ShardId, ShardMetadata, ShardMonitor,
+};
 use crate::{Error, Result, StorageConfig};
 
 use arrow_array::RecordBatch;
 use object_store::ObjectStore;
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -70,6 +73,8 @@ pub struct IngesterConfig {
     pub max_buffer_size_bytes: usize,
     /// WAL configuration
     pub wal: WalConfig,
+    /// Number of initial shards to provision (default 16)
+    pub initial_shard_count: u16,
 }
 
 impl Default for IngesterConfig {
@@ -83,6 +88,7 @@ impl Default for IngesterConfig {
             flush_parallelism: 4,
             max_buffer_size_bytes: 512 * 1024 * 1024, // 512MB
             wal: WalConfig::default(),
+            initial_shard_count: crate::sharding::DEFAULT_INITIAL_SHARD_COUNT,
         }
     }
 }
@@ -91,8 +97,10 @@ impl Default for IngesterConfig {
 pub struct Ingester {
     /// Configuration
     config: IngesterConfig,
-    /// Write buffer
-    buffer: Arc<RwLock<WriteBuffer>>,
+    /// Per-shard write buffers (shard_id → buffer)
+    buffers: Arc<RwLock<HashMap<ShardId, WriteBuffer>>>,
+    /// Cached shard ranges for routing (loaded from metadata)
+    shard_ranges: Arc<RwLock<Vec<ShardMetadata>>>,
     /// Object storage client
     object_store: Arc<dyn ObjectStore>,
     /// Metadata client
@@ -146,7 +154,8 @@ impl Ingester {
 
         Self {
             config,
-            buffer: Arc::new(RwLock::new(WriteBuffer::new())),
+            buffers: Arc::new(RwLock::new(HashMap::new())),
+            shard_ranges: Arc::new(RwLock::new(Vec::new())),
             object_store,
             metadata,
             parquet_writer: ParquetWriter::new(),
@@ -183,7 +192,8 @@ impl Ingester {
 
         Self {
             config,
-            buffer: Arc::new(RwLock::new(WriteBuffer::new())),
+            buffers: Arc::new(RwLock::new(HashMap::new())),
+            shard_ranges: Arc::new(RwLock::new(Vec::new())),
             object_store,
             metadata,
             parquet_writer: ParquetWriter::new(),
@@ -227,13 +237,17 @@ impl Ingester {
             if !entries.is_empty() {
                 let mut replayed = 0u64;
                 let mut max_seq = flushed_seq;
+                // During WAL recovery, all entries go to shard 0 (default).
+                // Shard ranges may not be loaded yet; proper routing happens on new writes.
+                let recovery_shard: ShardId = 0;
                 for entry in &entries {
                     match entry.batches() {
                         Ok(batches) => {
                             for batch in batches {
                                 let mut pending_batch = Some(batch);
                                 loop {
-                                    let mut buffer = self.buffer.write().await;
+                                    let mut buffers = self.buffers.write().await;
+                                    let buffer = buffers.entry(recovery_shard).or_default();
                                     let incoming = pending_batch.as_ref().ok_or_else(|| {
                                         Error::Internal("Missing pending batch".to_string())
                                     })?;
@@ -241,13 +255,9 @@ impl Ingester {
                                     // Keep recovery buffer schema-homogeneous so future flushes do not fail.
                                     if !buffer.schema_compatible(incoming) {
                                         let existing = buffer.take();
-                                        drop(buffer);
-                                        // Advance WAL seq before flush so flush_batches persists
-                                        // the correct sequence. Without this, a crash after the
-                                        // flush but before line `self.last_wal_seq.store(max_seq)`
-                                        // would replay already-flushed entries on next recovery.
+                                        drop(buffers);
                                         self.last_wal_seq.store(max_seq, Ordering::Release);
-                                        self.flush_batches(existing).await?;
+                                        self.flush_shard_batches(recovery_shard, existing).await?;
                                         continue;
                                     }
 
@@ -269,7 +279,10 @@ impl Ingester {
                     }
                 }
                 self.last_wal_seq.store(max_seq, Ordering::Release);
-                let buffer_rows = self.buffer.read().await.row_count();
+                let buffer_rows = {
+                    let buffers = self.buffers.read().await;
+                    buffers.values().map(|b| b.row_count()).sum::<usize>()
+                };
                 info!(
                     replayed_entries = replayed,
                     buffer_rows,
@@ -298,25 +311,10 @@ impl Ingester {
     /// behavior — fsync runs asynchronously on the configured interval.
     pub async fn write(&self, batch: RecordBatch) -> Result<()> {
         let start_time = std::time::Instant::now();
-        let batch_size = batch.get_array_memory_size();
         let row_count = batch.num_rows() as u64;
 
-        // Compute shard key for this batch (for monitoring)
-        let shard_id = self.compute_shard_id(&batch);
         let result = async {
-            // Check if shard is being split - if so, use dual-write
-            if let Some(split_state) = self.metadata.get_split_state(&shard_id.to_string()).await? {
-                use crate::sharding::SplitPhase;
-                if matches!(
-                    split_state.phase,
-                    SplitPhase::DualWrite | SplitPhase::Backfill
-                ) {
-                    info!("Shard {} is splitting, enabling dual-write mode", shard_id);
-                    return self.write_with_split_awareness(batch, shard_id).await;
-                }
-            }
-
-            // Normal single-write path
+            // WAL append (whole batch, before partitioning)
             if let Some(wal) = self.wal.as_ref() {
                 let seq = match wal.lock().await.append(&batch).await {
                     Ok(seq) => {
@@ -338,12 +336,38 @@ impl Ingester {
                 }
             }
 
-            self.append_to_buffer_and_maybe_flush(batch, batch_size).await?;
+            // Partition batch by shard and append to per-shard buffers
+            let ranges = self.shard_ranges.read().await;
+            let partitioned = self.partition_batch_by_shard(&batch, &ranges)?;
+            drop(ranges);
 
-            // Record write metrics for hot shard detection
-            let write_latency = start_time.elapsed();
-            self.shard_monitor
-                .record_write(&shard_id, batch_size, write_latency);
+            for (shard_id, shard_batch) in partitioned {
+                let batch_size = shard_batch.get_array_memory_size();
+
+                // Check for active split on this shard
+                if let Some(split_state) =
+                    self.metadata.get_split_state(&shard_id.to_string()).await?
+                {
+                    use crate::sharding::SplitPhase;
+                    if matches!(
+                        split_state.phase,
+                        SplitPhase::DualWrite | SplitPhase::Backfill
+                    ) {
+                        info!("Shard {} is splitting, enabling dual-write mode", shard_id);
+                        self.write_with_split_awareness(shard_batch, shard_id)
+                            .await?;
+                        continue;
+                    }
+                }
+
+                self.append_to_shard_buffer(shard_id, shard_batch, batch_size)
+                    .await?;
+
+                // Record write metrics for hot shard detection
+                let write_latency = start_time.elapsed();
+                self.shard_monitor
+                    .record_write(&shard_id, batch_size, write_latency);
+            }
 
             Ok(())
         }
@@ -354,7 +378,8 @@ impl Ingester {
         result
     }
 
-    /// Write with split awareness (dual-write to old and new shards)
+    /// Write with split awareness (dual-write to old and new shards).
+    /// WAL has already been appended by the caller.
     async fn write_with_split_awareness(&self, batch: RecordBatch, shard_id: ShardId) -> Result<()> {
         let split_state = self
             .metadata
@@ -362,29 +387,9 @@ impl Ingester {
             .await?
             .ok_or_else(|| Error::Internal("Split state disappeared".to_string()))?;
 
-        if let Some(wal) = self.wal.as_ref() {
-            let seq = match wal.lock().await.append(&batch).await {
-                Ok(seq) => {
-                    telemetry::record_wal_operation("append", "ok");
-                    seq
-                }
-                Err(e) => {
-                    telemetry::record_wal_operation("append", "error");
-                    return Err(e);
-                }
-            };
-            self.last_wal_seq.store(seq, Ordering::Release);
-        } else if self.config.wal.enabled {
-            telemetry::record_wal_operation("append", "error");
-            if !self.wal_warned.swap(true, Ordering::Relaxed) {
-                warn!(
-                    "WAL is enabled but not initialized - call ensure_wal() for crash durability"
-                );
-            }
-        }
-
         // Write to old shard first (for consistency during transition)
-        self.append_to_buffer_and_maybe_flush(batch.clone(), batch.get_array_memory_size())
+        let batch_size = batch.get_array_memory_size();
+        self.append_to_shard_buffer(shard_id, batch.clone(), batch_size)
             .await?;
 
         // Split batch by key range and write to new shards
@@ -500,22 +505,59 @@ impl Ingester {
         Ok((batch_a, batch_b))
     }
 
-    /// Compute shard ID for a batch based on tenant and metric
-    fn compute_shard_id(&self, batch: &RecordBatch) -> ShardId {
-        let metric_name = if let Some(col) = batch.column_by_name("metric_name") {
-            use arrow_array::cast::AsArray;
-            if let Some(arr) = col.as_string_opt::<i32>() {
-                arr.value(0).to_string()
-            } else {
-                "unknown".to_string()
-            }
-        } else {
-            "unknown".to_string()
-        };
+    /// Partition a batch into per-shard sub-batches using metric hash routing.
+    /// Sync, CPU-only — no metadata I/O.
+    fn partition_batch_by_shard(
+        &self,
+        batch: &RecordBatch,
+        ranges: &[ShardMetadata],
+    ) -> Result<HashMap<ShardId, RecordBatch>> {
+        // If no shard ranges loaded, everything goes to shard 0
+        if ranges.is_empty() {
+            let mut result = HashMap::new();
+            result.insert(0, batch.clone());
+            return Ok(result);
+        }
 
-        let hash = crate::sharding::hash_metric_name(&metric_name);
-        // For now, return hash as u32 (shard resolution will use cached ranges later)
-        hash as ShardId
+        use arrow_array::cast::AsArray;
+        let metric_col = batch
+            .column_by_name("metric_name")
+            .and_then(|c| c.as_string_opt::<i32>());
+
+        let mut indices_by_shard: HashMap<ShardId, Vec<u32>> = HashMap::new();
+        for i in 0..batch.num_rows() {
+            let metric_name = metric_col.map(|c| c.value(i)).unwrap_or("unknown");
+            let hash = hash_metric_name(metric_name);
+            let shard_id = find_shard_for_hash(hash, ranges).unwrap_or(0);
+            indices_by_shard.entry(shard_id).or_default().push(i as u32);
+        }
+
+        let mut result = HashMap::with_capacity(indices_by_shard.len());
+        for (shard_id, indices) in indices_by_shard {
+            let indices_array = arrow::array::UInt32Array::from(indices);
+            result.insert(
+                shard_id,
+                arrow::compute::take_record_batch(batch, &indices_array)?,
+            );
+        }
+        Ok(result)
+    }
+
+    /// Refresh shard ranges from metadata. Call after split events.
+    pub async fn refresh_shard_ranges(&self) -> Result<()> {
+        let shards = self.metadata.list_shards().await?;
+        let mut ranges = self.shard_ranges.write().await;
+        *ranges = shards;
+        info!(shard_count = ranges.len(), "Refreshed shard ranges");
+        Ok(())
+    }
+
+    /// Write a pre-partitioned batch directly to a specific shard's buffer.
+    /// Used by future IngestDispatcher for distributed routing.
+    pub async fn write_pre_partitioned(&self, shard_id: ShardId, batch: RecordBatch) -> Result<()> {
+        let batch_size = batch.get_array_memory_size();
+        self.append_to_shard_buffer(shard_id, batch, batch_size)
+            .await
     }
 
     /// Extract all unique metric names from a batch for topic routing
@@ -558,38 +600,50 @@ impl Ingester {
         self.topic_broadcast.subscribe(filter).await
     }
 
-    /// Check if flush is needed based on thresholds
+    /// Check if flush is needed based on thresholds for a single shard buffer
     fn should_flush(&self, buffer: &WriteBuffer) -> bool {
         buffer.row_count() >= self.config.flush_row_count
             || buffer.size_bytes() >= self.config.flush_size_bytes
     }
 
-    /// Append a batch, flushing existing buffered data first when schemas differ.
-    ///
-    /// This prevents heterogeneous RecordBatch concatenation failures during flush.
-    async fn append_to_buffer_and_maybe_flush(
+    /// Compute aggregate buffer size across all shards
+    fn aggregate_buffer_size(buffers: &HashMap<ShardId, WriteBuffer>) -> usize {
+        buffers.values().map(|b| b.size_bytes()).sum()
+    }
+
+    /// Append a batch to a specific shard's buffer, flushing if needed.
+    async fn append_to_shard_buffer(
         &self,
+        shard_id: ShardId,
         batch: RecordBatch,
         batch_size: usize,
     ) -> Result<()> {
         let mut pending_batch = Some(batch);
 
         loop {
-            let mut buffer = self.buffer.write().await;
+            let mut buffers = self.buffers.write().await;
 
             let incoming = pending_batch
                 .as_ref()
                 .ok_or_else(|| Error::Internal("Missing pending batch".to_string()))?;
 
-            // If schemas differ, flush current buffer before appending.
-            if !buffer.schema_compatible(incoming) {
-                let existing = buffer.take();
-                drop(buffer);
-                self.flush_batches(existing).await?;
+            // Ensure shard buffer exists
+            if !buffers.contains_key(&shard_id) {
+                buffers.insert(shard_id, WriteBuffer::new());
+            }
+
+            // Check schema compatibility
+            let schema_ok = buffers.get(&shard_id).unwrap().schema_compatible(incoming);
+            if !schema_ok {
+                let existing = buffers.get_mut(&shard_id).unwrap().take();
+                drop(buffers);
+                self.flush_shard_batches(shard_id, existing).await?;
                 continue;
             }
 
-            if buffer.size_bytes() + batch_size > self.config.max_buffer_size_bytes {
+            // Aggregate buffer fullness check across all shards
+            let total_size = Self::aggregate_buffer_size(&buffers);
+            if total_size + batch_size > self.config.max_buffer_size_bytes {
                 telemetry::record_buffer_fullness_ratio(1.0);
                 return Err(Error::BufferFull);
             }
@@ -597,30 +651,41 @@ impl Ingester {
             let incoming = pending_batch
                 .take()
                 .ok_or_else(|| Error::Internal("Missing pending batch".to_string()))?;
-            buffer.append(incoming)?;
-            let max_buffer_size = self.config.max_buffer_size_bytes.max(1) as f64;
-            telemetry::record_buffer_fullness_ratio(buffer.size_bytes() as f64 / max_buffer_size);
+            {
+                let buffer = buffers.get_mut(&shard_id).unwrap();
+                buffer.append(incoming)?;
+            }
 
-            if self.should_flush(&buffer) {
-                let batches = buffer.take();
-                drop(buffer);
-                self.flush_batches(batches).await?;
+            let max_buffer_size = self.config.max_buffer_size_bytes.max(1) as f64;
+            let new_total = Self::aggregate_buffer_size(&buffers);
+            telemetry::record_buffer_fullness_ratio(new_total as f64 / max_buffer_size);
+
+            let needs_flush = self.should_flush(buffers.get(&shard_id).unwrap());
+            if needs_flush {
+                let batches = buffers.get_mut(&shard_id).unwrap().take();
+                drop(buffers);
+                self.flush_shard_batches(shard_id, batches).await?;
             }
 
             return Ok(());
         }
     }
 
-    /// Flush batches to object storage
-    async fn flush_batches(&self, batches: Vec<RecordBatch>) -> Result<()> {
+    /// Flush batches for a specific shard to object storage
+    async fn flush_shard_batches(
+        &self,
+        shard_id: ShardId,
+        batches: Vec<RecordBatch>,
+    ) -> Result<()> {
         if batches.is_empty() {
             return Ok(());
         }
 
         info!(
+            shard_id,
             batch_count = batches.len(),
             total_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>(),
-            "Flushing batches to object storage"
+            "Flushing shard batches to object storage"
         );
 
         // Concatenate batches
@@ -630,8 +695,8 @@ impl Ingester {
         let parquet_bytes = self.parquet_writer.write_batch(&combined)?;
         let parquet_size = parquet_bytes.len() as u64;
 
-        // Generate path
-        let path = self.generate_path();
+        // Generate shard-qualified path
+        let path = self.generate_path(shard_id);
         debug!(path = %path, size_bytes = parquet_size, "Writing Parquet file");
 
         // Upload to object storage
@@ -640,7 +705,6 @@ impl Ingester {
             .await?;
 
         // Register in metadata store
-        let shard_id = self.compute_shard_id(&combined);
         let chunk_metadata = ChunkMetadata {
             path: path.clone(),
             min_timestamp: self.extract_min_timestamp(&combined)?,
@@ -670,9 +734,13 @@ impl Ingester {
             debug!("No topic broadcast subscribers: {}", e);
         }
 
-        // Truncate WAL after successful flush
+        // WAL truncation: only truncate when ALL shard buffers are empty
+        let all_empty = {
+            let buffers = self.buffers.read().await;
+            buffers.values().all(|b| b.is_empty())
+        };
         let flushed_up_to = self.last_wal_seq.load(Ordering::Acquire);
-        if flushed_up_to > 0 {
+        if all_empty && flushed_up_to > 0 {
             if let Some(wal) = self.wal.as_ref() {
                 if let Err(e) = wal.lock().await.truncate_before(flushed_up_to).await {
                     telemetry::record_wal_operation("truncate", "error");
@@ -705,47 +773,53 @@ impl Ingester {
             tokio::select! {
                 _ = interval.tick() => {
                     let should_flush = {
-                        let buffer = self.buffer.read().await;
+                        let buffers = self.buffers.read().await;
                         let last_flush = self.last_flush.read().await;
-                        !buffer.is_empty() && last_flush.elapsed() >= self.config.flush_interval
+                        let any_non_empty = buffers.values().any(|b| !b.is_empty());
+                        any_non_empty && last_flush.elapsed() >= self.config.flush_interval
                     };
 
                     if should_flush {
-                        let batches = {
-                            let mut buffer = self.buffer.write().await;
-                            buffer.take()
-                        };
-
-                        if let Err(e) = self.flush_batches(batches).await {
-                            error!("Flush timer failed: {}", e);
-                        }
+                        self.flush_all_shard_buffers().await;
                     }
                 }
                 _ = self.shutdown.cancelled() => {
                     info!("Flush timer shutting down, flushing remaining data");
-                    let batches = {
-                        let mut buffer = self.buffer.write().await;
-                        buffer.take()
-                    };
-                    if !batches.is_empty() {
-                        if let Err(e) = self.flush_batches(batches).await {
-                            error!("Final flush failed during shutdown: {}", e);
-                        }
-                    }
+                    self.flush_all_shard_buffers().await;
                     break;
                 }
             }
         }
     }
 
-    /// Generate a unique path for the Parquet file
-    fn generate_path(&self) -> String {
+    /// Flush all non-empty shard buffers sequentially.
+    async fn flush_all_shard_buffers(&self) {
+        // Collect shard IDs and their batches under a single lock
+        let to_flush: Vec<(ShardId, Vec<RecordBatch>)> = {
+            let mut buffers = self.buffers.write().await;
+            buffers
+                .iter_mut()
+                .filter(|(_, buf)| !buf.is_empty())
+                .map(|(&shard_id, buf)| (shard_id, buf.take()))
+                .collect()
+        };
+
+        for (shard_id, batches) in to_flush {
+            if let Err(e) = self.flush_shard_batches(shard_id, batches).await {
+                error!(shard_id, "Flush timer failed for shard: {}", e);
+            }
+        }
+    }
+
+    /// Generate a unique shard-qualified path for the Parquet file
+    fn generate_path(&self, shard_id: ShardId) -> String {
         let now = self.clock.now();
         let uuid = uuid::Uuid::new_v4();
 
         format!(
-            "{}/data/year={}/month={:02}/day={:02}/hour={:02}/chunk_{}.parquet",
+            "{}/data/shard={}/year={}/month={:02}/day={:02}/hour={:02}/chunk_{}.parquet",
             self.storage_config.tenant_id,
+            shard_id,
             now.format("%Y"),
             now.format("%m"),
             now.format("%d"),
@@ -803,13 +877,13 @@ impl Ingester {
         self.broadcast.subscribe()
     }
 
-    /// Get current buffer stats
+    /// Get current buffer stats (aggregated across all shard buffers)
     pub async fn buffer_stats(&self) -> BufferStats {
-        let buffer = self.buffer.read().await;
+        let buffers = self.buffers.read().await;
         BufferStats {
-            row_count: buffer.row_count(),
-            size_bytes: buffer.size_bytes(),
-            batch_count: buffer.batch_count(),
+            row_count: buffers.values().map(|b| b.row_count()).sum(),
+            size_bytes: buffers.values().map(|b| b.size_bytes()).sum(),
+            batch_count: buffers.values().map(|b| b.batch_count()).sum(),
         }
     }
 }

--- a/src/metadata/client.rs
+++ b/src/metadata/client.rs
@@ -186,4 +186,20 @@ pub trait MetadataClient: Send + Sync {
     async fn has_active_split(&self) -> Result<bool> {
         Ok(false) // Default: no splits active
     }
+
+    /// Get chunks for multiple shards
+    async fn get_chunks_for_shards(
+        &self,
+        range: TimeRange,
+        predicates: &[super::predicates::ColumnPredicate],
+        _shard_ids: &[crate::sharding::ShardId],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        // Default: fall back to predicate-only query
+        self.get_chunks_with_predicates(range, predicates).await
+    }
+
+    /// List all shard metadata
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
+        Ok(vec![])
+    }
 }

--- a/src/metadata/local.rs
+++ b/src/metadata/local.rs
@@ -511,7 +511,11 @@ impl MetadataClient for LocalMetadataClient {
     }
 
     async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
-        Ok(self.shard_metadata.iter().map(|e| e.value().clone()).collect())
+        Ok(self
+            .shard_metadata
+            .iter()
+            .map(|e| e.value().clone())
+            .collect())
     }
 
     async fn get_chunks_for_shards(
@@ -524,8 +528,12 @@ impl MetadataClient for LocalMetadataClient {
         if shard_ids.is_empty() {
             return Ok(all);
         }
-        let wanted: std::collections::HashSet<crate::sharding::ShardId> = shard_ids.iter().copied().collect();
-        Ok(all.into_iter().filter(|e| wanted.contains(&e.shard_id)).collect())
+        let wanted: std::collections::HashSet<crate::sharding::ShardId> =
+            shard_ids.iter().copied().collect();
+        Ok(all
+            .into_iter()
+            .filter(|e| wanted.contains(&e.shard_id))
+            .collect())
     }
 }
 

--- a/src/metadata/local.rs
+++ b/src/metadata/local.rs
@@ -340,12 +340,22 @@ impl MetadataClient for LocalMetadataClient {
     }
 
     async fn get_chunks_for_shard(&self, shard_id: &str) -> Result<Vec<TimeIndexEntry>> {
-        // In a real implementation, we'd have shard-to-chunk mappings
-        // For now, filter chunks by path pattern
+        // For numeric shard IDs: match by shard_id field, with path prefix fallback
+        // For non-numeric (UUID) shard IDs: match by path pattern only
+        let numeric_id = shard_id.parse::<crate::sharding::ShardId>().ok();
         let results: Vec<TimeIndexEntry> = self
             .chunks
             .iter()
-            .filter(|entry| entry.key().contains(shard_id))
+            .filter(|entry| {
+                if let Some(nid) = numeric_id {
+                    // Numeric: match field or path prefix (e.g. "1/chunk.parquet")
+                    entry.value().shard_id == nid
+                        || entry.key().starts_with(&format!("{}/", shard_id))
+                } else {
+                    // UUID-style: match by path containment
+                    entry.key().contains(shard_id)
+                }
+            })
             .map(|entry| TimeIndexEntry::from(entry.value()))
             .collect();
 
@@ -499,6 +509,24 @@ impl MetadataClient for LocalMetadataClient {
         }
         Ok(false)
     }
+
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
+        Ok(self.shard_metadata.iter().map(|e| e.value().clone()).collect())
+    }
+
+    async fn get_chunks_for_shards(
+        &self,
+        range: TimeRange,
+        _predicates: &[super::predicates::ColumnPredicate],
+        shard_ids: &[crate::sharding::ShardId],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        let all = self.get_chunks(range).await?;
+        if shard_ids.is_empty() {
+            return Ok(all);
+        }
+        let wanted: std::collections::HashSet<crate::sharding::ShardId> = shard_ids.iter().copied().collect();
+        Ok(all.into_iter().filter(|e| wanted.contains(&e.shard_id)).collect())
+    }
 }
 
 #[cfg(test)]
@@ -512,6 +540,7 @@ mod tests {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+            shard_id: 0,
         }
     }
 

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -54,6 +54,7 @@ pub struct TimeIndexEntry {
     pub max_timestamp: i64,
     pub row_count: u64,
     pub size_bytes: u64,
+    pub shard_id: crate::sharding::ShardId,
 }
 
 impl From<&ChunkMetadata> for TimeIndexEntry {
@@ -64,6 +65,7 @@ impl From<&ChunkMetadata> for TimeIndexEntry {
             max_timestamp: meta.max_timestamp,
             row_count: meta.row_count,
             size_bytes: meta.size_bytes,
+            shard_id: meta.shard_id,
         }
     }
 }

--- a/src/metadata/s3.rs
+++ b/src/metadata/s3.rs
@@ -96,9 +96,6 @@ pub struct ChunkMetadataExtended {
     /// Version/ETag for atomic operations
     #[serde(default, skip_serializing)]
     pub version: String,
-    /// Shard ID this chunk belongs to (None for legacy data)
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub shard_id: Option<String>,
 }
 
 /// Unified metadata catalog -- single S3 object, single ETag
@@ -817,7 +814,6 @@ impl ObjectStoreMetadataClient {
             column_stats: HashMap::new(),
             level: 0, // New chunks start at L0
             version: String::new(),
-            shard_id: None,
         };
 
         let catalog = cas_retry!({
@@ -1135,6 +1131,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                                 max_timestamp: extended.base.max_timestamp,
                                 row_count: extended.base.row_count,
                                 size_bytes: extended.base.size_bytes,
+                                shard_id: extended.base.shard_id,
                             });
                         } else {
                             pruned_count += 1;
@@ -1200,6 +1197,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                 max_timestamp: extended.base.max_timestamp,
                 row_count: extended.base.row_count,
                 size_bytes: extended.base.size_bytes,
+                shard_id: extended.base.shard_id,
             })
             .collect();
 
@@ -1538,13 +1536,14 @@ impl MetadataClient for ObjectStoreMetadataClient {
     async fn get_chunks_for_shard(&self, shard_id: &str) -> Result<Vec<TimeIndexEntry>> {
         let catalog = self.load_catalog_cached().await?;
 
-        // Filter chunks by shard_id field first, fall back to path.contains() for legacy data
+        // Filter chunks by numeric shard_id field, fall back to path.contains() for legacy data
         let results: Vec<TimeIndexEntry> = catalog
             .chunks
             .iter()
             .filter(|(path, extended)| {
-                if let Some(ref chunk_shard) = extended.shard_id {
-                    chunk_shard == shard_id
+                // Try numeric match first, fall back to path pattern for legacy data
+                if let Ok(numeric_id) = shard_id.parse::<crate::sharding::ShardId>() {
+                    extended.base.shard_id == numeric_id
                 } else {
                     // Legacy fallback: match by path substring
                     path.contains(shard_id)
@@ -1556,6 +1555,7 @@ impl MetadataClient for ObjectStoreMetadataClient {
                 max_timestamp: extended.base.max_timestamp,
                 row_count: extended.base.row_count,
                 size_bytes: extended.base.size_bytes,
+                shard_id: extended.base.shard_id,
             })
             .collect();
 
@@ -2084,6 +2084,80 @@ impl MetadataClient for ObjectStoreMetadataClient {
         Ok(states
             .values()
             .any(|s| matches!(s.phase, SplitPhase::DualWrite | SplitPhase::Backfill)))
+    }
+
+    async fn list_shards(&self) -> Result<Vec<crate::sharding::ShardMetadata>> {
+        use futures::TryStreamExt;
+
+        let prefix = Path::from_iter([&self.config.metadata_prefix, "shards/"]);
+        let list_result = self.object_store.list(Some(&prefix));
+        let objects: Vec<_> = list_result.try_collect().await.map_err(|e| {
+            Error::Internal(format!("Failed to list shard metadata: {}", e))
+        })?;
+
+        let mut shards = Vec::new();
+        for obj in objects {
+            let key = obj.location.to_string();
+            if !key.ends_with(".json") {
+                continue;
+            }
+            match self.object_store.get(&obj.location).await {
+                Ok(result) => {
+                    let bytes = result.bytes().await?;
+                    let content = String::from_utf8_lossy(&bytes);
+                    match serde_json::from_str::<crate::sharding::ShardMetadata>(&content) {
+                        Ok(metadata) => shards.push(metadata),
+                        Err(e) => {
+                            warn!("Failed to parse shard metadata at {}: {}", key, e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to load shard metadata at {}: {}", key, e);
+                }
+            }
+        }
+
+        Ok(shards)
+    }
+
+    async fn get_chunks_for_shards(
+        &self,
+        range: TimeRange,
+        _predicates: &[super::predicates::ColumnPredicate],
+        shard_ids: &[crate::sharding::ShardId],
+    ) -> Result<Vec<TimeIndexEntry>> {
+        let catalog = self.load_catalog_cached().await?;
+
+        if shard_ids.is_empty() {
+            // No shard filter -- return all chunks in range
+            return self.get_chunks(range).await;
+        }
+
+        let wanted: std::collections::HashSet<crate::sharding::ShardId> =
+            shard_ids.iter().copied().collect();
+
+        let results: Vec<TimeIndexEntry> = catalog
+            .chunks
+            .iter()
+            .filter(|(_, extended)| {
+                wanted.contains(&extended.base.shard_id)
+                    && range.overlaps(&TimeRange::new(
+                        extended.base.min_timestamp,
+                        extended.base.max_timestamp,
+                    ))
+            })
+            .map(|(path, extended)| TimeIndexEntry {
+                chunk_path: path.clone(),
+                min_timestamp: extended.base.min_timestamp,
+                max_timestamp: extended.base.max_timestamp,
+                row_count: extended.base.row_count,
+                size_bytes: extended.base.size_bytes,
+                shard_id: extended.base.shard_id,
+            })
+            .collect();
+
+        Ok(results)
     }
 }
 

--- a/src/metadata/s3.rs
+++ b/src/metadata/s3.rs
@@ -2091,9 +2091,10 @@ impl MetadataClient for ObjectStoreMetadataClient {
 
         let prefix = Path::from_iter([&self.config.metadata_prefix, "shards/"]);
         let list_result = self.object_store.list(Some(&prefix));
-        let objects: Vec<_> = list_result.try_collect().await.map_err(|e| {
-            Error::Internal(format!("Failed to list shard metadata: {}", e))
-        })?;
+        let objects: Vec<_> = list_result
+            .try_collect()
+            .await
+            .map_err(|e| Error::Internal(format!("Failed to list shard metadata: {}", e)))?;
 
         let mut shards = Vec::new();
         for obj in objects {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -9,6 +9,7 @@ mod cache;
 mod cached_store;
 mod dedup;
 mod engine;
+pub mod planner;
 mod router;
 mod streaming;
 mod telemetry;
@@ -183,11 +184,20 @@ impl QueryNode {
                 (Err(e), _) | (_, Err(e)) => return Err(e),
             };
 
+            // Shard pruning: if predicates constrain metric_name, narrow to matching shards
+            let shards = self.metadata.list_shards().await.unwrap_or_default();
+            let candidate_shards = planner::candidate_shard_ids(&predicates, &shards);
+
             // Get relevant chunks from metadata with predicate pushdown
-            let chunks = self
-                .metadata
-                .get_chunks_with_predicates(time_range, &predicates)
-                .await?;
+            let chunks = if let Some(ref shard_ids) = candidate_shards {
+                self.metadata
+                    .get_chunks_for_shards(time_range, &predicates, shard_ids)
+                    .await?
+            } else {
+                self.metadata
+                    .get_chunks_with_predicates(time_range, &predicates)
+                    .await?
+            };
             let bytes_scanned = chunks.iter().map(|chunk| chunk.size_bytes).sum::<u64>();
 
             // Pin chunks to prevent GC during query execution (RAII guard unpins on drop)

--- a/src/query/planner.rs
+++ b/src/query/planner.rs
@@ -68,10 +68,18 @@ fn collect_metrics_from_predicate(pred: &ColumnPredicate, metrics: &mut Vec<Stri
             collect_metrics_from_predicate(right, metrics);
         }
         ColumnPredicate::Or(left, right) => {
-            // For OR, both sides must contribute metric names for pruning to be safe.
-            // However, we collect from both — the union is correct for shard selection.
-            collect_metrics_from_predicate(left, metrics);
-            collect_metrics_from_predicate(right, metrics);
+            // Only prune when BOTH sides constrain metric_name. If one side is
+            // metric-unconstrained (e.g. `host = 'a'`), every shard may match,
+            // so collecting metric names from only one arm would incorrectly
+            // exclude valid shards from the scan.
+            let mut left_metrics = Vec::new();
+            let mut right_metrics = Vec::new();
+            collect_metrics_from_predicate(left, &mut left_metrics);
+            collect_metrics_from_predicate(right, &mut right_metrics);
+            if !left_metrics.is_empty() && !right_metrics.is_empty() {
+                metrics.extend(left_metrics);
+                metrics.extend(right_metrics);
+            }
         }
         _ => {}
     }

--- a/src/query/planner.rs
+++ b/src/query/planner.rs
@@ -1,0 +1,193 @@
+//! Shard pruning planner for query optimization.
+//!
+//! Given query predicates and the current shard topology, determines which
+//! shards may contain matching data. Queries with exact metric_name predicates
+//! can skip shards whose hash range does not contain the metric's hash.
+
+use crate::metadata::predicates::{ColumnPredicate, PredicateValue};
+use crate::sharding::{hash_metric_name, ShardId, ShardMetadata, ShardState};
+
+/// Determine which shards may contain data matching the given predicates.
+///
+/// Returns `Some(shard_ids)` when exact metric name predicates allow pruning,
+/// or `None` when the query is unconstrained and all shards must be scanned.
+pub fn candidate_shard_ids(
+    predicates: &[ColumnPredicate],
+    shards: &[ShardMetadata],
+) -> Option<Vec<ShardId>> {
+    let metric_names = extract_exact_metrics(predicates);
+    if metric_names.is_empty() {
+        return None; // No metric constraint → scan all shards
+    }
+
+    let mut result = std::collections::BTreeSet::new();
+    for metric in &metric_names {
+        let hash = hash_metric_name(metric) as u32;
+        for shard in shards {
+            // Skip shards pending deletion — their data has been migrated
+            if matches!(shard.state, ShardState::PendingDeletion { .. }) {
+                continue;
+            }
+            if hash >= shard.hash_range.0 && hash < shard.hash_range.1 {
+                result.insert(shard.shard_id);
+            }
+        }
+    }
+
+    Some(result.into_iter().collect())
+}
+
+/// Extract exact metric name values from predicates.
+///
+/// Handles: `Eq("metric_name", String(v))`, `In("metric_name", [String(v), ...])`,
+/// and `And(left, right)` / `Or(left, right)` combinations.
+fn extract_exact_metrics(predicates: &[ColumnPredicate]) -> Vec<String> {
+    let mut metrics = Vec::new();
+    for pred in predicates {
+        collect_metrics_from_predicate(pred, &mut metrics);
+    }
+    metrics.sort();
+    metrics.dedup();
+    metrics
+}
+
+fn collect_metrics_from_predicate(pred: &ColumnPredicate, metrics: &mut Vec<String>) {
+    match pred {
+        ColumnPredicate::Eq(col, PredicateValue::String(val)) if col == "metric_name" => {
+            metrics.push(val.clone());
+        }
+        ColumnPredicate::In(col, values) if col == "metric_name" => {
+            for val in values {
+                if let PredicateValue::String(s) = val {
+                    metrics.push(s.clone());
+                }
+            }
+        }
+        ColumnPredicate::And(left, right) => {
+            collect_metrics_from_predicate(left, metrics);
+            collect_metrics_from_predicate(right, metrics);
+        }
+        ColumnPredicate::Or(left, right) => {
+            // For OR, both sides must contribute metric names for pruning to be safe.
+            // However, we collect from both — the union is correct for shard selection.
+            collect_metrics_from_predicate(left, metrics);
+            collect_metrics_from_predicate(right, metrics);
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sharding::{ReplicaInfo, ShardMetadata, ShardState};
+
+    fn make_shard(id: ShardId, range: (u32, u32)) -> ShardMetadata {
+        ShardMetadata {
+            shard_id: id,
+            hash_range: range,
+            generation: 1,
+            key_range: (vec![], vec![]),
+            replicas: vec![ReplicaInfo {
+                replica_id: "r1".into(),
+                node_id: "n1".into(),
+                is_leader: true,
+            }],
+            state: ShardState::Active,
+            min_time: 0,
+            max_time: i64::MAX,
+        }
+    }
+
+    #[test]
+    fn test_no_predicates_returns_none() {
+        let shards = vec![make_shard(0, (0, 0x8000)), make_shard(1, (0x8000, 0x10000))];
+        assert!(candidate_shard_ids(&[], &shards).is_none());
+    }
+
+    #[test]
+    fn test_exact_metric_prunes_to_one_shard() {
+        let shards = vec![make_shard(0, (0, 0x8000)), make_shard(1, (0x8000, 0x10000))];
+
+        let hash = hash_metric_name("cpu_usage") as u32;
+        let expected_shard = if hash < 0x8000 { 0 } else { 1 };
+
+        let predicates = vec![ColumnPredicate::Eq(
+            "metric_name".to_string(),
+            PredicateValue::String("cpu_usage".to_string()),
+        )];
+
+        let result = candidate_shard_ids(&predicates, &shards).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], expected_shard);
+    }
+
+    #[test]
+    fn test_in_predicate_returns_multiple_shards() {
+        // Use 4 shards so different metrics can land in different shards
+        let shards = vec![
+            make_shard(0, (0, 0x4000)),
+            make_shard(1, (0x4000, 0x8000)),
+            make_shard(2, (0x8000, 0xC000)),
+            make_shard(3, (0xC000, 0x10000)),
+        ];
+
+        let predicates = vec![ColumnPredicate::In(
+            "metric_name".to_string(),
+            vec![
+                PredicateValue::String("cpu_usage".to_string()),
+                PredicateValue::String("mem_usage".to_string()),
+                PredicateValue::String("disk_io".to_string()),
+            ],
+        )];
+
+        let result = candidate_shard_ids(&predicates, &shards).unwrap();
+        // Should return at least 1 shard, at most 3
+        assert!(!result.is_empty());
+        assert!(result.len() <= 3);
+    }
+
+    #[test]
+    fn test_pending_deletion_shards_excluded() {
+        let mut shard = make_shard(0, (0, 0x10000));
+        shard.state = ShardState::PendingDeletion { delete_after: 0 };
+
+        let predicates = vec![ColumnPredicate::Eq(
+            "metric_name".to_string(),
+            PredicateValue::String("cpu_usage".to_string()),
+        )];
+
+        let result = candidate_shard_ids(&predicates, &[shard]).unwrap();
+        assert!(result.is_empty(), "PendingDeletion shard should be excluded");
+    }
+
+    #[test]
+    fn test_splitting_shards_included() {
+        let mut shard = make_shard(0, (0, 0x10000));
+        shard.state = ShardState::Splitting {
+            new_shards: vec![1, 2],
+        };
+
+        let predicates = vec![ColumnPredicate::Eq(
+            "metric_name".to_string(),
+            PredicateValue::String("cpu_usage".to_string()),
+        )];
+
+        let result = candidate_shard_ids(&predicates, &[shard]).unwrap();
+        assert_eq!(result.len(), 1, "Splitting shard should be included");
+    }
+
+    #[test]
+    fn test_non_metric_predicate_returns_none() {
+        let shards = vec![make_shard(0, (0, 0x10000))];
+        let predicates = vec![ColumnPredicate::Eq(
+            "host".to_string(),
+            PredicateValue::String("server-1".to_string()),
+        )];
+
+        assert!(
+            candidate_shard_ids(&predicates, &shards).is_none(),
+            "Non-metric predicates should return None (full scan)"
+        );
+    }
+}

--- a/src/query/planner.rs
+++ b/src/query/planner.rs
@@ -158,7 +158,10 @@ mod tests {
         )];
 
         let result = candidate_shard_ids(&predicates, &[shard]).unwrap();
-        assert!(result.is_empty(), "PendingDeletion shard should be excluded");
+        assert!(
+            result.is_empty(),
+            "PendingDeletion shard should be excluded"
+        );
     }
 
     #[test]

--- a/src/sharding/mod.rs
+++ b/src/sharding/mod.rs
@@ -100,10 +100,14 @@ pub fn hash_in_range(hash: u16, range: (u32, u32)) -> bool {
 }
 
 /// Find which shard owns a given metric hash.
+///
+/// Excludes `PendingDeletion` shards: their data has been migrated to child
+/// shards, so routing writes there would target a shard scheduled for cleanup.
 pub fn find_shard_for_hash(hash: u16, shards: &[ShardMetadata]) -> Option<ShardId> {
     let h = hash as u32;
     shards
         .iter()
+        .filter(|s| !matches!(s.state, ShardState::PendingDeletion { .. }))
         .find(|s| h >= s.hash_range.0 && h < s.hash_range.1)
         .map(|s| s.shard_id)
 }

--- a/src/sharding/mod.rs
+++ b/src/sharding/mod.rs
@@ -1,7 +1,15 @@
 //! Dynamic sharding and hot shard rebalancing
 //!
-//! Automatically scales ingest/query capacity and rebalances hot shards
-//! without downtime.
+//! ## Shard Model
+//!
+//! **Shard key = `metric_hash`** (u16): `xxhash64(metric_name) & 0xFFFF`.
+//! Tenant isolation is structural (separate S3 prefix + metadata catalog).
+//!
+//! **Initial layout**: N fixed shards per tenant (configurable, default 16),
+//! each covering `1/N` of the 16-bit metric hash space.
+//!
+//! **Auto-split**: The existing 5-phase split protocol splits hot shards
+//! at the midpoint of their hash range.
 
 mod monitor;
 mod rebalancer;
@@ -13,22 +21,26 @@ pub use rebalancer::RebalanceStrategy;
 pub use router::ShardRouter;
 pub use splitter::{ShardSplitter, SplitPhase, SplitProgress};
 
+use std::hash::Hasher;
 use std::time::Duration;
+use twox_hash::XxHash64;
 
-/// Shard identifier
-pub type ShardId = String;
+/// Shard identifier — sequential u32 assigned at shard creation.
+///
+/// When shard 3 splits, children get the next available IDs (e.g. 16, 17).
+pub type ShardId = u32;
 
-/// Time bucket for sharding
+/// Default number of initial shards per tenant.
+pub const DEFAULT_INITIAL_SHARD_COUNT: u16 = 16;
+
+/// Time bucket for sharding (legacy, kept for backward compat with splitter)
 #[derive(Debug, Clone, Copy)]
 pub struct TimeBucket {
-    /// Start of the bucket (nanoseconds)
     pub start: i64,
-    /// Duration of the bucket
     pub duration: Duration,
 }
 
 impl TimeBucket {
-    /// Create a 5-minute bucket for a timestamp
     pub fn five_minute(timestamp: i64) -> Self {
         let nanos_per_5min = 5 * 60 * 1_000_000_000i64;
         let start = (timestamp / nanos_per_5min) * nanos_per_5min;
@@ -38,14 +50,14 @@ impl TimeBucket {
         }
     }
 
-    /// Round to nearest 5-minute boundary
     pub fn round_to_5min(timestamp: i64) -> i64 {
         let nanos_per_5min = 5 * 60 * 1_000_000_000i64;
         (timestamp / nanos_per_5min) * nanos_per_5min
     }
 }
 
-/// Shard key structure
+/// Legacy shard key structure — kept for backward compat with router tests.
+/// New code should use `hash_metric_name()` directly.
 #[derive(Debug, Clone)]
 pub struct ShardKey {
     pub tenant_id: u32,
@@ -54,21 +66,14 @@ pub struct ShardKey {
 }
 
 impl ShardKey {
-    /// Create a shard key from components
     pub fn new(tenant_id: u32, metric_name: &str, timestamp: i64) -> Self {
-        use std::hash::{Hash, Hasher};
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        metric_name.hash(&mut hasher);
-        let metric_hash = (hasher.finish() & 0xFFFF) as u16;
-
         Self {
             tenant_id,
-            metric_hash,
+            metric_hash: hash_metric_name(metric_name),
             time_bucket: TimeBucket::five_minute(timestamp),
         }
     }
 
-    /// Convert to bytes for routing
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(14);
         bytes.extend_from_slice(&self.tenant_id.to_be_bytes());
@@ -78,14 +83,63 @@ impl ShardKey {
     }
 }
 
+// ── Core shard key functions ────────────────────────────────────────────
+
+/// Compute a 16-bit metric hash for shard routing (xxhash64, seed 0).
+pub fn hash_metric_name(metric_name: &str) -> u16 {
+    let mut hasher = XxHash64::with_seed(0);
+    hasher.write(metric_name.as_bytes());
+    (hasher.finish() & 0xFFFF) as u16
+}
+
+/// Check if a metric hash falls in a shard's range [start, end).
+/// Ranges use u32 to avoid wraparound: the last shard has end = 0x10000.
+pub fn hash_in_range(hash: u16, range: (u32, u32)) -> bool {
+    let h = hash as u32;
+    h >= range.0 && h < range.1
+}
+
+/// Find which shard owns a given metric hash.
+pub fn find_shard_for_hash(hash: u16, shards: &[ShardMetadata]) -> Option<ShardId> {
+    let h = hash as u32;
+    shards
+        .iter()
+        .find(|s| h >= s.hash_range.0 && h < s.hash_range.1)
+        .map(|s| s.shard_id)
+}
+
+/// Create initial shard metadata with `num_shards` partitions covering [0, 0x10000).
+pub fn initial_shards(num_shards: u16) -> Vec<ShardMetadata> {
+    let step = 0x10000u32 / num_shards as u32;
+    (0..num_shards)
+        .map(|i| {
+            let range_start = i as u32 * step;
+            let range_end = if i == num_shards - 1 {
+                0x10000u32
+            } else {
+                (i as u32 + 1) * step
+            };
+            ShardMetadata {
+                shard_id: i as ShardId,
+                hash_range: (range_start, range_end),
+                generation: 0,
+                state: ShardState::Active,
+                replicas: vec![],
+                key_range: (vec![], vec![]),
+                min_time: 0,
+                max_time: 0,
+            }
+        })
+        .collect()
+}
+
+// ── Data types ──────────────────────────────────────────────────────────
+
 /// Shard state
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ShardState {
-    /// Shard is active and accepting writes/queries
     Active,
-    /// Shard is being split
     Splitting { new_shards: Vec<ShardId> },
-    /// Shard is pending deletion
     PendingDeletion { delete_after: i64 },
 }
 
@@ -101,7 +155,11 @@ pub struct ReplicaInfo {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ShardMetadata {
     pub shard_id: ShardId,
+    /// Metric hash range [start, end) — u32 so last shard can have end = 0x10000
+    #[serde(default)]
+    pub hash_range: (u32, u32),
     pub generation: u64,
+    /// Legacy byte-range key range (kept for backward compat with router/splitter)
     pub key_range: (Vec<u8>, Vec<u8>),
     pub replicas: Vec<ReplicaInfo>,
     pub state: ShardState,
@@ -110,13 +168,55 @@ pub struct ShardMetadata {
 }
 
 impl ShardMetadata {
-    /// Get the leader replica
     pub fn leader_replica(&self) -> Option<&ReplicaInfo> {
         self.replicas.iter().find(|r| r.is_leader)
     }
 
-    /// Check if the shard is active
     pub fn is_active(&self) -> bool {
         self.state == ShardState::Active
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hash_deterministic() {
+        assert_eq!(hash_metric_name("cpu_usage"), hash_metric_name("cpu_usage"));
+    }
+
+    #[test]
+    fn test_hash_distribution() {
+        assert_ne!(hash_metric_name("cpu_usage"), hash_metric_name("memory_usage"));
+    }
+
+    #[test]
+    fn test_hash_in_range() {
+        assert!(hash_in_range(0x0500, (0x0000, 0x1000)));
+        assert!(!hash_in_range(0x1500, (0x0000, 0x1000)));
+        assert!(!hash_in_range(0x1000, (0x0000, 0x1000))); // half-open
+    }
+
+    #[test]
+    fn test_initial_shards_16() {
+        let shards = initial_shards(16);
+        assert_eq!(shards.len(), 16);
+        assert_eq!(shards[0].hash_range.0, 0);
+        assert_eq!(shards[15].hash_range.1, 0x10000);
+        for i in 0..15 {
+            assert_eq!(shards[i].hash_range.1, shards[i + 1].hash_range.0);
+        }
+    }
+
+    #[test]
+    fn test_find_shard_for_hash() {
+        let shards = initial_shards(4);
+        let h = hash_metric_name("cpu_usage");
+        let shard_id = find_shard_for_hash(h, &shards);
+        assert!(shard_id.is_some());
+        let id = shard_id.unwrap();
+        let shard = shards.iter().find(|s| s.shard_id == id).unwrap();
+        assert!(hash_in_range(h, shard.hash_range));
     }
 }

--- a/src/sharding/mod.rs
+++ b/src/sharding/mod.rs
@@ -188,7 +188,10 @@ mod tests {
 
     #[test]
     fn test_hash_distribution() {
-        assert_ne!(hash_metric_name("cpu_usage"), hash_metric_name("memory_usage"));
+        assert_ne!(
+            hash_metric_name("cpu_usage"),
+            hash_metric_name("memory_usage")
+        );
     }
 
     #[test]

--- a/src/sharding/monitor.rs
+++ b/src/sharding/monitor.rs
@@ -167,7 +167,7 @@ impl ShardMonitor {
     pub fn record_write(&self, shard_id: &ShardId, bytes: usize, latency: Duration) {
         let mut entry = self
             .metrics
-            .entry(shard_id.clone())
+            .entry(*shard_id)
             .or_insert_with(|| ShardMetrics::new(self.config.detection_window));
         entry.record_write(bytes, latency);
     }
@@ -176,7 +176,7 @@ impl ShardMonitor {
     pub fn record_cpu(&self, shard_id: &ShardId, utilization: f64) {
         let mut entry = self
             .metrics
-            .entry(shard_id.clone())
+            .entry(*shard_id)
             .or_insert_with(|| ShardMetrics::new(self.config.detection_window));
         entry.record_cpu(utilization);
     }
@@ -188,7 +188,7 @@ impl ShardMonitor {
         let mut max_p99_latency = 0.0f64;
 
         for mut entry in self.metrics.iter_mut() {
-            let shard_id = entry.key().clone();
+            let shard_id = *entry.key();
             let metrics = entry.value_mut();
             let write_rate = metrics.write_qps.rate_per_second();
             let p99_latency = metrics.p99_latency.avg();
@@ -276,7 +276,7 @@ mod tests {
         };
 
         let monitor = ShardMonitor::new(config);
-        let shard_id = "shard-1".to_string();
+        let shard_id: ShardId = 1;
 
         // Record many writes quickly to generate high QPS
         for _ in 0..100 {

--- a/src/sharding/rebalancer.rs
+++ b/src/sharding/rebalancer.rs
@@ -116,7 +116,8 @@ mod tests {
         let strategy = RebalanceStrategy::default();
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![], vec![]),
             replicas: vec![

--- a/src/sharding/rebalancer.rs
+++ b/src/sharding/rebalancer.rs
@@ -31,7 +31,7 @@ impl RebalanceStrategy {
                 if target_replica.replica_id != current_leader.replica_id {
                     // Try lease transfer first (cheap, ~100ms, no data copy)
                     return Ok(RebalanceAction::TransferLease {
-                        shard_id: shard.shard_id.clone(),
+                        shard_id: shard.shard_id,
                         from_replica: current_leader.replica_id.clone(),
                         to_replica: target_replica.replica_id.clone(),
                     });
@@ -43,7 +43,7 @@ impl RebalanceStrategy {
         if let Some((target_node, _)) = self.find_underloaded_node(node_loads) {
             if let Some(leader) = shard.leader_replica() {
                 return Ok(RebalanceAction::MoveReplica {
-                    shard_id: shard.shard_id.clone(),
+                    shard_id: shard.shard_id,
                     from_node: leader.node_id.clone(),
                     to_node: target_node,
                 });

--- a/src/sharding/router.rs
+++ b/src/sharding/router.rs
@@ -72,7 +72,7 @@ impl ShardRouter {
     /// Rejects updates with a lower generation than the cached entry to
     /// prevent stale metadata from overwriting fresher data.
     pub fn update_routing(&self, shard: ShardMetadata) {
-        let shard_id = shard.shard_id.clone();
+        let shard_id = shard.shard_id;
         // Only update if the new generation is >= the cached generation
         if let Some(existing) = self.cache.get(&shard_id) {
             if shard.generation < existing.shard.generation {
@@ -161,7 +161,8 @@ mod tests {
         let router = ShardRouter::default();
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1u32,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],
@@ -176,7 +177,7 @@ mod tests {
         let found = router.get_shard(&key);
 
         assert!(found.is_some());
-        assert_eq!(found.unwrap().shard_id, "shard-1");
+        assert_eq!(found.unwrap().shard_id, 1);
     }
 
     #[test]
@@ -184,12 +185,13 @@ mod tests {
         let router = ShardRouter::default();
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1u32,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],
             state: ShardState::Splitting {
-                new_shards: vec!["shard-1a".to_string(), "shard-1b".to_string()],
+                new_shards: vec![16, 17],
             },
             min_time: 0,
             max_time: 0,
@@ -209,7 +211,8 @@ mod tests {
         let router = ShardRouter::default();
 
         let shard_v2 = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1u32,
+            hash_range: (0, 0x10000),
             generation: 2,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],
@@ -221,7 +224,8 @@ mod tests {
 
         // Try to update with older generation
         let shard_v1 = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1u32,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],
@@ -241,7 +245,8 @@ mod tests {
         let router = ShardRouter::default();
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1u32,
+            hash_range: (0, 0x10000),
             generation: 3,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],
@@ -264,7 +269,8 @@ mod tests {
         let router = ShardRouter::default();
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1u32,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],
@@ -274,7 +280,7 @@ mod tests {
         };
 
         router.update_routing(shard);
-        router.invalidate(&"shard-1".to_string());
+        router.invalidate(&1);
 
         let key = ShardKey::new(1, "cpu", 1000000000);
         let found = router.get_shard(&key);

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -164,8 +164,8 @@ impl ShardSplitter {
     /// If the process crashes at any point, call `resume_split()` with
     /// the same `old_shard` to continue from where it left off.
     pub async fn execute_split_with_monitoring(&self, shard: &ShardMetadata) -> Result<()> {
-        let shard_id = &shard.shard_id;
-        info!("Starting 5-phase split for shard: {}", shard_id);
+        let shard_id_str = shard.shard_id.to_string();
+        info!("Starting 5-phase split for shard: {}", shard_id_str);
 
         // Phase 1: Preparation
         let (new_shard_a, new_shard_b) = self.split_shard(shard).await?;
@@ -173,7 +173,7 @@ impl ShardSplitter {
 
         // Persist initial progress before any metadata changes
         let mut progress = SplitProgress::new(
-            shard_id,
+            &shard_id_str,
             vec![new_shard_a.clone(), new_shard_b.clone()],
             split_point.clone(),
         );
@@ -182,7 +182,7 @@ impl ShardSplitter {
         // Store split state in metadata
         self.metadata
             .start_split(
-                shard_id,
+                &shard_id_str,
                 vec![new_shard_a.clone(), new_shard_b.clone()],
                 split_point.clone(),
             )
@@ -333,10 +333,14 @@ impl ShardSplitter {
         let split_ts =
             i64::from_be_bytes(split_state.split_point[..8].try_into().unwrap_or([0u8; 8]));
 
+        // Split the hash range at the midpoint
+        let hash_mid = (old_metadata.hash_range.0 + old_metadata.hash_range.1) / 2;
+
         // Step 1: Create shard A (idempotent — skipped if already done)
         if !progress.shard_a_created {
             let new_shard_a = ShardMetadata {
-                shard_id: split_state.new_shards[0].clone(),
+                shard_id: 0, // placeholder — string ID used in metadata client
+                hash_range: (old_metadata.hash_range.0, hash_mid),
                 generation: 0,
                 key_range: (
                     old_metadata.key_range.0.clone(),
@@ -348,7 +352,7 @@ impl ShardSplitter {
                 max_time: split_ts,
             };
             self.metadata
-                .update_shard_metadata(&new_shard_a.shard_id, &new_shard_a, 0)
+                .update_shard_metadata(&split_state.new_shards[0], &new_shard_a, 0)
                 .await?;
             progress.shard_a_created = true;
             self.persist_progress(progress).await?;
@@ -357,7 +361,8 @@ impl ShardSplitter {
         // Step 2: Create shard B
         if !progress.shard_b_created {
             let new_shard_b = ShardMetadata {
-                shard_id: split_state.new_shards[1].clone(),
+                shard_id: 0, // placeholder — string ID used in metadata client
+                hash_range: (hash_mid, old_metadata.hash_range.1),
                 generation: 0,
                 key_range: (
                     split_state.split_point.clone(),
@@ -369,7 +374,7 @@ impl ShardSplitter {
                 max_time: old_metadata.max_time,
             };
             self.metadata
-                .update_shard_metadata(&new_shard_b.shard_id, &new_shard_b, 0)
+                .update_shard_metadata(&split_state.new_shards[1], &new_shard_b, 0)
                 .await?;
             progress.shard_b_created = true;
             self.persist_progress(progress).await?;
@@ -402,19 +407,21 @@ impl ShardSplitter {
     // ── Individual phase implementations ─────────────────────────────
 
     /// Split a hot shard into two (Phase 1: Preparation)
-    pub async fn split_shard(&self, shard: &ShardMetadata) -> Result<(ShardId, ShardId)> {
+    ///
+    /// Returns String IDs because the metadata client's split API is string-based.
+    pub async fn split_shard(&self, shard: &ShardMetadata) -> Result<(String, String)> {
         let split_point = self.calculate_split_point(shard);
 
-        let new_shard_a = ShardId::from(uuid::Uuid::new_v4().to_string());
-        let new_shard_b = ShardId::from(uuid::Uuid::new_v4().to_string());
+        let new_shard_a = uuid::Uuid::new_v4().to_string();
+        let new_shard_b = uuid::Uuid::new_v4().to_string();
 
         let _pending_shards = [
             PendingShard {
-                id: new_shard_a.clone(),
+                id: 0, // placeholder — real ID assigned at cutover
                 range: (shard.key_range.0.clone(), split_point.clone()),
             },
             PendingShard {
-                id: new_shard_b.clone(),
+                id: 0, // placeholder — real ID assigned at cutover
                 range: (split_point, shard.key_range.1.clone()),
             },
         ];
@@ -709,6 +716,7 @@ impl ShardSplitter {
             max_timestamp,
             row_count: batch.num_rows() as u64,
             size_bytes: bytes_len as u64,
+            shard_id: 0, // backfill data — shard assignment handled by metadata layer
         };
         self.metadata.register_chunk(path, &metadata).await?;
 
@@ -762,7 +770,8 @@ mod tests {
         let splitter = ShardSplitter::new(metadata, object_store);
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![ReplicaInfo {
@@ -789,7 +798,8 @@ mod tests {
         let splitter = ShardSplitter::new(metadata, object_store);
 
         let shard = ShardMetadata {
-            shard_id: "shard-1".to_string(),
+            shard_id: 1,
+            hash_range: (0, 0x10000),
             generation: 1,
             key_range: (vec![0, 0, 0, 0], vec![255, 255, 255, 255]),
             replicas: vec![],

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -332,11 +332,8 @@ impl ShardSplitter {
         let current_generation = old_metadata.generation;
 
         // The split point is the hash range midpoint (4-byte u32)
-        let hash_mid = u32::from_be_bytes(
-            split_state.split_point[..4]
-                .try_into()
-                .unwrap_or([0u8; 4]),
-        );
+        let hash_mid =
+            u32::from_be_bytes(split_state.split_point[..4].try_into().unwrap_or([0u8; 4]));
 
         // Step 1: Create shard A (idempotent — skipped if already done)
         if !progress.shard_a_created {
@@ -634,11 +631,9 @@ impl ShardSplitter {
     ) -> Result<(RecordBatch, RecordBatch)> {
         use arrow_array::cast::AsArray;
 
-        let split_hash = u32::from_be_bytes(
-            split_point
-                .try_into()
-                .map_err(|_| crate::Error::Internal("Invalid split point (expected 4 bytes)".to_string()))?,
-        );
+        let split_hash = u32::from_be_bytes(split_point.try_into().map_err(|_| {
+            crate::Error::Internal("Invalid split point (expected 4 bytes)".to_string())
+        })?);
 
         let metric_col = batch
             .column_by_name("metric_name")

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -3,12 +3,12 @@
 //! Each phase transition is persisted to object storage so that a crash at any
 //! point can be recovered by calling `resume_split()`.
 
-use super::{ShardId, ShardMetadata, ShardState, TimeBucket};
+use super::{ShardId, ShardMetadata, ShardState};
 use crate::ingester::ChunkMetadata;
 use crate::metadata::MetadataClient;
 use crate::Result;
 use arrow::array::RecordBatch;
-use arrow::datatypes::DataType;
+
 use bytes::Bytes;
 use object_store::ObjectStore;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
@@ -330,11 +330,13 @@ impl ShardSplitter {
             .ok_or_else(|| crate::Error::ShardNotFound(old_shard.to_string()))?;
 
         let current_generation = old_metadata.generation;
-        let split_ts =
-            i64::from_be_bytes(split_state.split_point[..8].try_into().unwrap_or([0u8; 8]));
 
-        // Split the hash range at the midpoint
-        let hash_mid = (old_metadata.hash_range.0 + old_metadata.hash_range.1) / 2;
+        // The split point is the hash range midpoint (4-byte u32)
+        let hash_mid = u32::from_be_bytes(
+            split_state.split_point[..4]
+                .try_into()
+                .unwrap_or([0u8; 4]),
+        );
 
         // Step 1: Create shard A (idempotent — skipped if already done)
         if !progress.shard_a_created {
@@ -342,14 +344,11 @@ impl ShardSplitter {
                 shard_id: 0, // placeholder — string ID used in metadata client
                 hash_range: (old_metadata.hash_range.0, hash_mid),
                 generation: 0,
-                key_range: (
-                    old_metadata.key_range.0.clone(),
-                    split_state.split_point.clone(),
-                ),
+                key_range: (old_metadata.key_range.0.clone(), vec![]),
                 replicas: old_metadata.replicas.clone(),
                 state: ShardState::Active,
                 min_time: old_metadata.min_time,
-                max_time: split_ts,
+                max_time: old_metadata.max_time,
             };
             self.metadata
                 .update_shard_metadata(&split_state.new_shards[0], &new_shard_a, 0)
@@ -364,13 +363,10 @@ impl ShardSplitter {
                 shard_id: 0, // placeholder — string ID used in metadata client
                 hash_range: (hash_mid, old_metadata.hash_range.1),
                 generation: 0,
-                key_range: (
-                    split_state.split_point.clone(),
-                    old_metadata.key_range.1.clone(),
-                ),
+                key_range: (vec![], old_metadata.key_range.1.clone()),
                 replicas: old_metadata.replicas.clone(),
                 state: ShardState::Active,
-                min_time: split_ts,
+                min_time: old_metadata.min_time,
                 max_time: old_metadata.max_time,
             };
             self.metadata
@@ -627,38 +623,34 @@ impl ShardSplitter {
     // ── Helpers ──────────────────────────────────────────────────────
 
     /// Split a RecordBatch into two based on timestamp split point
+    /// Split a batch by metric hash against the split point.
+    ///
+    /// Rows whose `hash_metric_name(metric_name)` falls below the split point
+    /// go to batch_a (left child), the rest to batch_b (right child).
     fn split_batch(
         &self,
         batch: &RecordBatch,
         split_point: &[u8],
     ) -> Result<(RecordBatch, RecordBatch)> {
-        let ts_column = batch
-            .column_by_name("timestamp")
-            .ok_or_else(|| crate::Error::Internal("Missing timestamp column".to_string()))?;
+        use arrow_array::cast::AsArray;
 
-        let ts_array = if let DataType::Int64 = ts_column.data_type() {
-            ts_column
-                .as_any()
-                .downcast_ref::<arrow::array::Int64Array>()
-                .ok_or_else(|| crate::Error::Internal("Timestamp not Int64".to_string()))?
-        } else {
-            return Err(crate::Error::Internal(
-                "Timestamp column is not Int64".to_string(),
-            ));
-        };
+        let split_hash = u32::from_be_bytes(
+            split_point
+                .try_into()
+                .map_err(|_| crate::Error::Internal("Invalid split point (expected 4 bytes)".to_string()))?,
+        );
+
+        let metric_col = batch
+            .column_by_name("metric_name")
+            .and_then(|c| c.as_string_opt::<i32>());
 
         let mut indices_a = Vec::new();
         let mut indices_b = Vec::new();
 
-        let split_ts = i64::from_be_bytes(
-            split_point
-                .try_into()
-                .map_err(|_| crate::Error::Internal("Invalid split point".to_string()))?,
-        );
-
         for i in 0..batch.num_rows() {
-            let ts = ts_array.value(i);
-            if ts < split_ts {
+            let metric_name = metric_col.map(|c| c.value(i)).unwrap_or("unknown");
+            let hash = super::hash_metric_name(metric_name) as u32;
+            if hash < split_hash {
                 indices_a.push(i as u32);
             } else {
                 indices_b.push(i as u32);
@@ -746,13 +738,13 @@ impl ShardSplitter {
         out
     }
 
-    /// Calculate the split point based on time
+    /// Calculate the split point as the midpoint of the shard's hash range.
+    ///
+    /// Returns the midpoint as a 4-byte big-endian u32 (the metric hash space
+    /// boundary between the two child shards).
     fn calculate_split_point(&self, shard: &ShardMetadata) -> Vec<u8> {
-        let time_range = shard.max_time - shard.min_time;
-        let mid_time = shard.min_time + time_range / 2;
-
-        let rounded = TimeBucket::round_to_5min(mid_time);
-        rounded.to_be_bytes().to_vec()
+        let midpoint = (shard.hash_range.0 + shard.hash_range.1) / 2;
+        midpoint.to_be_bytes().to_vec()
     }
 }
 
@@ -811,7 +803,11 @@ mod tests {
         let split_point = splitter.calculate_split_point(&shard);
 
         assert!(!split_point.is_empty());
-        assert_eq!(split_point.len(), 8); // i64 bytes
+        assert_eq!(split_point.len(), 4); // u32 bytes (hash midpoint)
+
+        // Midpoint of (0, 0x10000) should be 0x8000
+        let midpoint = u32::from_be_bytes(split_point.try_into().unwrap());
+        assert_eq!(midpoint, 0x8000);
     }
 
     #[tokio::test]
@@ -823,7 +819,7 @@ mod tests {
         let mut progress = SplitProgress::new(
             "shard-old",
             vec!["shard-a".to_string(), "shard-b".to_string()],
-            vec![0, 0, 0, 0, 0, 0, 0, 42],
+            vec![0, 0, 0, 42],
         );
         progress.completed_phase = Some(SplitPhase::DualWrite);
         progress.shard_a_created = true;

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -10,17 +10,17 @@ use crate::Result;
 use arrow::array::RecordBatch;
 
 use bytes::Bytes;
-use std::hash::Hasher as _;
-use twox_hash::XxHash64;
 use object_store::ObjectStore;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 use std::collections::BTreeSet;
+use std::hash::Hasher as _;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
+use twox_hash::XxHash64;
 
 /// Split phase
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]

--- a/src/sharding/splitter.rs
+++ b/src/sharding/splitter.rs
@@ -10,6 +10,8 @@ use crate::Result;
 use arrow::array::RecordBatch;
 
 use bytes::Bytes;
+use std::hash::Hasher as _;
+use twox_hash::XxHash64;
 use object_store::ObjectStore;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::arrow::ArrowWriter;
@@ -338,7 +340,7 @@ impl ShardSplitter {
         // Step 1: Create shard A (idempotent — skipped if already done)
         if !progress.shard_a_created {
             let new_shard_a = ShardMetadata {
-                shard_id: 0, // placeholder — string ID used in metadata client
+                shard_id: Self::shard_id_from_str(&split_state.new_shards[0]),
                 hash_range: (old_metadata.hash_range.0, hash_mid),
                 generation: 0,
                 key_range: (old_metadata.key_range.0.clone(), vec![]),
@@ -357,7 +359,7 @@ impl ShardSplitter {
         // Step 2: Create shard B
         if !progress.shard_b_created {
             let new_shard_b = ShardMetadata {
-                shard_id: 0, // placeholder — string ID used in metadata client
+                shard_id: Self::shard_id_from_str(&split_state.new_shards[1]),
                 hash_range: (hash_mid, old_metadata.hash_range.1),
                 generation: 0,
                 key_range: (vec![], old_metadata.key_range.1.clone()),
@@ -398,6 +400,17 @@ impl ShardSplitter {
     }
 
     // ── Individual phase implementations ─────────────────────────────
+
+    /// Derive a stable `ShardId` (u32) from a string shard key (e.g. a UUID).
+    ///
+    /// The metadata client uses string keys; the in-memory `ShardMetadata.shard_id`
+    /// is a u32 used for routing. We hash the string so child shards get distinct,
+    /// deterministic numeric IDs rather than the placeholder `0`.
+    fn shard_id_from_str(s: &str) -> ShardId {
+        let mut h = XxHash64::with_seed(0);
+        h.write(s.as_bytes());
+        (h.finish() & 0xFFFF_FFFF) as u32
+    }
 
     /// Split a hot shard into two (Phase 1: Preparation)
     ///

--- a/tests/atomic_metadata_tests.rs
+++ b/tests/atomic_metadata_tests.rs
@@ -36,7 +36,7 @@ async fn test_concurrent_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
-        shard_id: 0,
+                shard_id: 0,
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -100,7 +100,7 @@ async fn test_atomic_retry_on_conflict() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 100,
                 size_bytes: 1024,
-        shard_id: 0,
+                shard_id: 0,
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -160,7 +160,7 @@ async fn test_heavy_concurrent_load() {
                     max_timestamp: ((task_id * CHUNKS_PER_TASK + chunk_id) as i64 + 1) * 1000,
                     row_count: 1000,
                     size_bytes: 1024 * 1024,
-        shard_id: 0,
+                    shard_id: 0,
                 };
 
                 if client.register_chunk(&chunk.path, &chunk).await.is_ok() {
@@ -235,7 +235,7 @@ async fn test_atomic_compaction_completion() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -306,7 +306,7 @@ async fn test_concurrent_compactions() {
                 max_timestamp: ((group * 3 + chunk) as i64 + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
-        shard_id: 0,
+                shard_id: 0,
             };
             metadata_client.register_chunk(&path, &meta).await.unwrap();
         }
@@ -319,7 +319,7 @@ async fn test_concurrent_compactions() {
             max_timestamp: ((group * 3) as i64 + 3) * 1000,
             row_count: 3000,
             size_bytes: 3 * 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client
             .register_chunk(&target, &meta)

--- a/tests/atomic_metadata_tests.rs
+++ b/tests/atomic_metadata_tests.rs
@@ -36,6 +36,7 @@ async fn test_concurrent_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
+        shard_id: 0,
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -80,6 +81,7 @@ async fn test_atomic_retry_on_conflict() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&chunk.path, &chunk)
@@ -98,6 +100,7 @@ async fn test_atomic_retry_on_conflict() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 100,
                 size_bytes: 1024,
+        shard_id: 0,
             };
 
             client.register_chunk(&chunk.path, &chunk).await
@@ -157,6 +160,7 @@ async fn test_heavy_concurrent_load() {
                     max_timestamp: ((task_id * CHUNKS_PER_TASK + chunk_id) as i64 + 1) * 1000,
                     row_count: 1000,
                     size_bytes: 1024 * 1024,
+        shard_id: 0,
                 };
 
                 if client.register_chunk(&chunk.path, &chunk).await.is_ok() {
@@ -231,6 +235,7 @@ async fn test_atomic_compaction_completion() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -242,6 +247,7 @@ async fn test_atomic_compaction_completion() {
         max_timestamp: 3000,
         row_count: 3000,
         size_bytes: 3 * 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk("compacted.parquet", &target_chunk)
@@ -300,6 +306,7 @@ async fn test_concurrent_compactions() {
                 max_timestamp: ((group * 3 + chunk) as i64 + 1) * 1000,
                 row_count: 1000,
                 size_bytes: 1024 * 1024,
+        shard_id: 0,
             };
             metadata_client.register_chunk(&path, &meta).await.unwrap();
         }
@@ -312,6 +319,7 @@ async fn test_concurrent_compactions() {
             max_timestamp: ((group * 3) as i64 + 3) * 1000,
             row_count: 3000,
             size_bytes: 3 * 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client
             .register_chunk(&target, &meta)

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -678,7 +678,7 @@ async fn test_complete_split_on_nonexistent_shard() {
 #[test]
 fn test_shard_monitor_metrics_after_writes() {
     let monitor = ShardMonitor::new(HotShardConfig::default());
-    let shard_id = "shard-metrics".to_string();
+    let shard_id: u32 = 1;
 
     // Record several writes
     for _ in 0..10 {
@@ -704,7 +704,7 @@ fn test_shard_monitor_metrics_after_writes() {
 #[test]
 fn test_shard_monitor_cpu_recording() {
     let monitor = ShardMonitor::new(HotShardConfig::default());
-    let shard_id = "shard-cpu".to_string();
+    let shard_id: u32 = 2;
 
     monitor.record_cpu(&shard_id, 0.65);
     monitor.record_cpu(&shard_id, 0.70);
@@ -730,7 +730,7 @@ fn test_shard_monitor_cool_shard() {
     let monitor = ShardMonitor::new(HotShardConfig::default());
 
     // Record a single small write - should not be hot
-    let shard_id = "shard-1".to_string();
+    let shard_id: u32 = 1;
     monitor.record_write(&shard_id, 100, Duration::from_millis(1));
 
     let actions = monitor.evaluate_shards();
@@ -742,12 +742,12 @@ fn test_shard_monitor_metrics_retrieval() {
     let monitor = ShardMonitor::new(HotShardConfig::default());
 
     // No metrics for unknown shard
-    assert!(monitor.get_metrics(&"unknown".to_string()).is_none());
+    assert!(monitor.get_metrics(&99u32).is_none());
 
     // Record a write, then verify metrics exist
-    let shard_id = "shard-1".to_string();
+    let shard_id: u32 = 1;
     monitor.record_write(&shard_id, 1000, Duration::from_millis(5));
-    let metrics = monitor.get_metrics(&"shard-1".to_string());
+    let metrics = monitor.get_metrics(&1u32);
     assert!(
         metrics.is_some(),
         "Should have metrics after recording write"
@@ -842,6 +842,7 @@ async fn test_time_index_rebuild() {
             max_timestamp: (i + 1) * nanos_per_hour - 1,
             row_count: 100,
             size_bytes: 1024,
+        shard_id: 0,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -883,6 +884,7 @@ async fn test_compaction_level_tracking_through_metadata() {
             max_timestamp: (i + 1) * 1000 - 1,
             row_count: 10,
             size_bytes: 100,
+        shard_id: 0,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -894,6 +896,7 @@ async fn test_compaction_level_tracking_through_metadata() {
         max_timestamp: 2999,
         row_count: 30,
         size_bytes: 300,
+        shard_id: 0,
     };
     client.register_chunk(&target.path, &target).await.unwrap();
 
@@ -1037,7 +1040,8 @@ async fn test_s3_shard_metadata_lifecycle() {
     let client = Arc::new(S3MetadataClient::new(object_store, config));
 
     let shard = ShardMetadata {
-        shard_id: "shard-s3-test".to_string(),
+        shard_id: 1,
+        hash_range: (0, 0x10000),
         generation: 0,
         key_range: (vec![0u8; 8], vec![255u8; 8]),
         replicas: vec![ReplicaInfo {
@@ -1052,12 +1056,12 @@ async fn test_s3_shard_metadata_lifecycle() {
 
     // Create shard (generation 0 -> 1)
     client
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Verify it exists
-    let retrieved = client.get_shard_metadata("shard-s3-test").await.unwrap();
+    let retrieved = client.get_shard_metadata(&shard.shard_id.to_string()).await.unwrap();
     assert!(retrieved.is_some());
     let retrieved = retrieved.unwrap();
     assert_eq!(retrieved.generation, 1);
@@ -1065,13 +1069,13 @@ async fn test_s3_shard_metadata_lifecycle() {
 
     // Update with correct generation (1 -> 2)
     client
-        .update_shard_metadata("shard-s3-test", &retrieved, 1)
+        .update_shard_metadata(&shard.shard_id.to_string(), &retrieved, 1)
         .await
         .unwrap();
 
     // Verify generation incremented
     let updated = client
-        .get_shard_metadata("shard-s3-test")
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .unwrap();
@@ -1079,7 +1083,7 @@ async fn test_s3_shard_metadata_lifecycle() {
 
     // Stale generation should fail
     let result = client
-        .update_shard_metadata("shard-s3-test", &updated, 1) // stale: actual is 2
+        .update_shard_metadata(&shard.shard_id.to_string(), &updated, 1) // stale: actual is 2
         .await;
     assert!(result.is_err());
     match result.unwrap_err() {
@@ -1228,6 +1232,7 @@ async fn test_concurrent_split_and_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 10,
                 size_bytes: 100,
+        shard_id: 0,
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
         });
@@ -1259,6 +1264,7 @@ async fn test_concurrent_split_and_chunk_registration() {
             max_timestamp: (i + 1) * 1000,
             row_count: 10,
             size_bytes: 100,
+        shard_id: 0,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }

--- a/tests/coverage_gap_tests.rs
+++ b/tests/coverage_gap_tests.rs
@@ -842,7 +842,7 @@ async fn test_time_index_rebuild() {
             max_timestamp: (i + 1) * nanos_per_hour - 1,
             row_count: 100,
             size_bytes: 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -884,7 +884,7 @@ async fn test_compaction_level_tracking_through_metadata() {
             max_timestamp: (i + 1) * 1000 - 1,
             row_count: 10,
             size_bytes: 100,
-        shard_id: 0,
+            shard_id: 0,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }
@@ -1061,7 +1061,10 @@ async fn test_s3_shard_metadata_lifecycle() {
         .unwrap();
 
     // Verify it exists
-    let retrieved = client.get_shard_metadata(&shard.shard_id.to_string()).await.unwrap();
+    let retrieved = client
+        .get_shard_metadata(&shard.shard_id.to_string())
+        .await
+        .unwrap();
     assert!(retrieved.is_some());
     let retrieved = retrieved.unwrap();
     assert_eq!(retrieved.generation, 1);
@@ -1232,7 +1235,7 @@ async fn test_concurrent_split_and_chunk_registration() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: 10,
                 size_bytes: 100,
-        shard_id: 0,
+                shard_id: 0,
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
         });
@@ -1264,7 +1267,7 @@ async fn test_concurrent_split_and_chunk_registration() {
             max_timestamp: (i + 1) * 1000,
             row_count: 10,
             size_bytes: 100,
-        shard_id: 0,
+            shard_id: 0,
         };
         client.register_chunk(&chunk.path, &chunk).await.unwrap();
     }

--- a/tests/error_path_tests.rs
+++ b/tests/error_path_tests.rs
@@ -1087,7 +1087,7 @@ async fn test_concurrent_registration_data_integrity() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: (i + 1) as u64 * 100, // Unique row count per chunk
                 size_bytes: (i + 1) as u64 * 1024,
-        shard_id: 0,
+                shard_id: 0,
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
             (i, chunk.row_count)

--- a/tests/error_path_tests.rs
+++ b/tests/error_path_tests.rs
@@ -225,6 +225,7 @@ async fn test_get_nonexistent_chunk() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -264,6 +265,7 @@ async fn test_list_chunks_uninitialized_metadata() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
     client.delete_chunk("temp.parquet").await.unwrap();
@@ -294,6 +296,7 @@ async fn test_get_chunks_empty_time_range() {
         max_timestamp: 2000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: 0,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -329,6 +332,7 @@ async fn test_metadata_cas_fails_loudly_when_unsafe_overwrite_disabled() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
 
     client
@@ -342,6 +346,7 @@ async fn test_metadata_cas_fails_loudly_when_unsafe_overwrite_disabled() {
         max_timestamp: 3000,
         row_count: 20,
         size_bytes: 200,
+        shard_id: 0,
     };
 
     let result = client.register_chunk(&second.path, &second).await;
@@ -386,6 +391,7 @@ async fn test_metadata_cas_fallback_overwrite_when_enabled() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
 
     client
@@ -399,6 +405,7 @@ async fn test_metadata_cas_fallback_overwrite_when_enabled() {
         max_timestamp: 3000,
         row_count: 20,
         size_bytes: 200,
+        shard_id: 0,
     };
 
     client
@@ -445,6 +452,7 @@ async fn test_register_chunk_with_zero_timestamps() {
         max_timestamp: 0,
         row_count: 0,
         size_bytes: 0,
+        shard_id: 0,
     };
 
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
@@ -478,6 +486,7 @@ async fn test_register_duplicate_chunk_path() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: 0,
     };
 
     let chunk2 = ChunkMetadata {
@@ -486,6 +495,7 @@ async fn test_register_duplicate_chunk_path() {
         max_timestamp: 3000,
         row_count: 200,
         size_bytes: 2048,
+        shard_id: 0,
     };
 
     client.register_chunk(&chunk1.path, &chunk1).await.unwrap();
@@ -511,7 +521,8 @@ async fn test_cas_stale_generation_error_format() {
     let metadata = Arc::new(LocalMetadataClient::new());
 
     let shard = ShardMetadata {
-        shard_id: "shard-1".to_string(),
+        shard_id: 1,
+        hash_range: (0, 0x10000),
         generation: 0,
         key_range: (vec![0u8; 8], vec![255u8; 8]),
         replicas: vec![ReplicaInfo {
@@ -526,13 +537,13 @@ async fn test_cas_stale_generation_error_format() {
 
     // Create with generation 0
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Try with stale generation
     let result = metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await;
 
     assert!(result.is_err());
@@ -561,7 +572,8 @@ async fn test_cas_max_generation_values() {
     let metadata = Arc::new(LocalMetadataClient::new());
 
     let shard = ShardMetadata {
-        shard_id: "shard-large-gen".to_string(),
+        shard_id: 99,
+        hash_range: (0, 0x10000),
         generation: 0,
         key_range: (vec![0u8; 8], vec![255u8; 8]),
         replicas: vec![],
@@ -572,27 +584,27 @@ async fn test_cas_max_generation_values() {
 
     // Initial creation
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Perform many updates to get a high generation number
     for gen in 1..=100u64 {
         let current = metadata
-            .get_shard_metadata(&shard.shard_id)
+            .get_shard_metadata(&shard.shard_id.to_string())
             .await
             .unwrap()
             .unwrap();
         assert_eq!(current.generation, gen);
 
         metadata
-            .update_shard_metadata(&shard.shard_id, &current, gen)
+            .update_shard_metadata(&shard.shard_id.to_string(), &current, gen)
             .await
             .unwrap();
     }
 
     let final_shard = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .unwrap();
@@ -622,6 +634,7 @@ async fn test_compaction_with_single_source() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: 0,
     };
     client.register_chunk(&source.path, &source).await.unwrap();
 
@@ -631,6 +644,7 @@ async fn test_compaction_with_single_source() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: 0,
     };
     client.register_chunk(&target.path, &target).await.unwrap();
 
@@ -674,6 +688,7 @@ async fn test_l0_candidates_empty() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
     let target = ChunkMetadata {
@@ -682,6 +697,7 @@ async fn test_l0_candidates_empty() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
     client.register_chunk(&target.path, &target).await.unwrap();
     client
@@ -716,6 +732,7 @@ async fn test_level_candidates_nonexistent_level() {
         max_timestamp: 1000,
         row_count: 10,
         size_bytes: 100,
+        shard_id: 0,
     };
     client.register_chunk(&chunk.path, &chunk).await.unwrap();
 
@@ -1070,6 +1087,7 @@ async fn test_concurrent_registration_data_integrity() {
                 max_timestamp: (i + 1) * 1000,
                 row_count: (i + 1) as u64 * 100, // Unique row count per chunk
                 size_bytes: (i + 1) as u64 * 1024,
+        shard_id: 0,
             };
             client.register_chunk(&chunk.path, &chunk).await.unwrap();
             (i, chunk.row_count)

--- a/tests/generation_cas_tests.rs
+++ b/tests/generation_cas_tests.rs
@@ -15,7 +15,9 @@ use tokio::task::JoinSet;
 /// client uses `shard_id.to_string()` as the DashMap key.
 fn create_test_shard(id: &str, generation: u64) -> ShardMetadata {
     // Use a simple hash of the id string to get a unique numeric shard_id
-    let shard_id = id.bytes().fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+    let shard_id = id
+        .bytes()
+        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
     ShardMetadata {
         shard_id,
         hash_range: (0, 0x10000),

--- a/tests/generation_cas_tests.rs
+++ b/tests/generation_cas_tests.rs
@@ -10,9 +10,15 @@ use std::sync::Arc;
 use tokio::task::JoinSet;
 
 /// Helper to create a test shard
+///
+/// The `id` string is hashed to a stable u32 for shard_id. The metadata
+/// client uses `shard_id.to_string()` as the DashMap key.
 fn create_test_shard(id: &str, generation: u64) -> ShardMetadata {
+    // Use a simple hash of the id string to get a unique numeric shard_id
+    let shard_id = id.bytes().fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
     ShardMetadata {
-        shard_id: id.to_string(),
+        shard_id,
+        hash_range: (0, 0x10000),
         generation,
         key_range: (vec![0u8; 8], vec![255u8; 8]),
         replicas: vec![ReplicaInfo {
@@ -35,13 +41,13 @@ async fn test_generation_increments() {
 
     // Initial update (generation 0 -> 1)
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Verify generation incremented
     let updated = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -50,12 +56,12 @@ async fn test_generation_increments() {
 
     // Update again (generation 1 -> 2)
     metadata
-        .update_shard_metadata(&shard.shard_id, &updated, 1)
+        .update_shard_metadata(&shard.shard_id.to_string(), &updated, 1)
         .await
         .unwrap();
 
     let updated2 = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -72,13 +78,13 @@ async fn test_stale_generation_rejected() {
 
     // Initial update
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Try to update with stale generation (0 when current is 1)
     let result = metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await;
 
     assert!(result.is_err(), "Should reject stale generation");
@@ -101,7 +107,7 @@ async fn test_concurrent_cas_updates() {
 
     // Initial setup
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
@@ -110,13 +116,13 @@ async fn test_concurrent_cas_updates() {
 
     for i in 0..10 {
         let client = metadata.clone();
-        let shard_id = shard.shard_id.clone();
+        let shard_id_str = shard.shard_id.to_string();
 
         tasks.spawn(async move {
             // Each task tries multiple times with the latest generation
             for attempt in 0..5 {
                 // Get current metadata
-                let current = match client.get_shard_metadata(&shard_id).await.unwrap() {
+                let current = match client.get_shard_metadata(&shard_id_str).await.unwrap() {
                     Some(s) => s,
                     None => return Err(format!("Task {} attempt {}: Shard not found", i, attempt)),
                 };
@@ -126,7 +132,7 @@ async fn test_concurrent_cas_updates() {
                 updated.min_time = i * 1000; // Just change something
 
                 match client
-                    .update_shard_metadata(&shard_id, &updated, current.generation)
+                    .update_shard_metadata(&shard_id_str, &updated, current.generation)
                     .await
                 {
                     Ok(_) => return Ok(i),
@@ -166,7 +172,7 @@ async fn test_concurrent_cas_updates() {
 
     // Verify final generation
     let final_shard = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -186,19 +192,19 @@ async fn test_cas_prevents_lost_updates() {
 
     // Initial setup
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Simulate two processes with stale reads
     let shard1 = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
 
     let shard2 = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -212,7 +218,7 @@ async fn test_cas_prevents_lost_updates() {
     updated1.min_time = 1000;
 
     metadata
-        .update_shard_metadata(&shard.shard_id, &updated1, 1)
+        .update_shard_metadata(&shard.shard_id.to_string(), &updated1, 1)
         .await
         .unwrap();
 
@@ -221,7 +227,7 @@ async fn test_cas_prevents_lost_updates() {
     updated2.min_time = 2000;
 
     let result = metadata
-        .update_shard_metadata(&shard.shard_id, &updated2, 1)
+        .update_shard_metadata(&shard.shard_id.to_string(), &updated2, 1)
         .await;
 
     assert!(
@@ -231,7 +237,7 @@ async fn test_cas_prevents_lost_updates() {
 
     // Verify first update was preserved
     let final_shard = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -253,30 +259,30 @@ async fn test_cas_with_state_transitions() {
 
     // Initial setup
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Transition to Splitting
     let current = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
 
     let mut splitting = current.clone();
     splitting.state = ShardState::Splitting {
-        new_shards: vec!["shard-2".to_string(), "shard-3".to_string()],
+        new_shards: vec![2, 3],
     };
 
     metadata
-        .update_shard_metadata(&shard.shard_id, &splitting, current.generation)
+        .update_shard_metadata(&shard.shard_id.to_string(), &splitting, current.generation)
         .await
         .unwrap();
 
     // Verify state changed
     let updated = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -295,13 +301,13 @@ async fn test_cas_with_state_transitions() {
     };
 
     metadata
-        .update_shard_metadata(&shard.shard_id, &pending, updated.generation)
+        .update_shard_metadata(&shard.shard_id.to_string(), &pending, updated.generation)
         .await
         .unwrap();
 
     // Verify final state
     let final_shard = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -325,13 +331,13 @@ async fn test_new_shard_creation() {
 
     // Create new shard (expected_generation = 0 for new shards)
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     // Verify it was created with generation 1
     let created = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -349,19 +355,19 @@ async fn test_independent_shard_updates() {
     let shard2 = create_test_shard("shard-2", 0);
 
     metadata
-        .update_shard_metadata(&shard1.shard_id, &shard1, 0)
+        .update_shard_metadata(&shard1.shard_id.to_string(), &shard1, 0)
         .await
         .unwrap();
 
     metadata
-        .update_shard_metadata(&shard2.shard_id, &shard2, 0)
+        .update_shard_metadata(&shard2.shard_id.to_string(), &shard2, 0)
         .await
         .unwrap();
 
     // Update shard1 multiple times
     for i in 1..=3 {
         let current = metadata
-            .get_shard_metadata(&shard1.shard_id)
+            .get_shard_metadata(&shard1.shard_id.to_string())
             .await
             .unwrap()
             .expect("Shard should exist");
@@ -370,14 +376,14 @@ async fn test_independent_shard_updates() {
         updated.min_time = i * 1000;
 
         metadata
-            .update_shard_metadata(&shard1.shard_id, &updated, current.generation)
+            .update_shard_metadata(&shard1.shard_id.to_string(), &updated, current.generation)
             .await
             .unwrap();
     }
 
     // Verify shard1 has generation 4
     let final1 = metadata
-        .get_shard_metadata(&shard1.shard_id)
+        .get_shard_metadata(&shard1.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -385,7 +391,7 @@ async fn test_independent_shard_updates() {
 
     // Verify shard2 still has generation 1
     let final2 = metadata
-        .get_shard_metadata(&shard2.shard_id)
+        .get_shard_metadata(&shard2.shard_id.to_string())
         .await
         .unwrap()
         .expect("Shard should exist");
@@ -400,7 +406,7 @@ async fn test_retry_with_backoff() {
     let shard = create_test_shard("shard-1", 0);
 
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
@@ -417,7 +423,7 @@ async fn test_retry_with_backoff() {
 
         // Get current generation
         let current = metadata
-            .get_shard_metadata(&shard.shard_id)
+            .get_shard_metadata(&shard.shard_id.to_string())
             .await
             .unwrap()
             .expect("Shard should exist");
@@ -427,7 +433,7 @@ async fn test_retry_with_backoff() {
         updated.min_time = 5000;
 
         match metadata
-            .update_shard_metadata(&shard.shard_id, &updated, current.generation)
+            .update_shard_metadata(&shard.shard_id.to_string(), &updated, current.generation)
             .await
         {
             Ok(_) => break,

--- a/tests/level_tracking_tests.rs
+++ b/tests/level_tracking_tests.rs
@@ -75,7 +75,7 @@ async fn test_l0_to_l1_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -147,7 +147,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -179,7 +179,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: ((i + 2) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -282,7 +282,7 @@ async fn test_full_level_progression() {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         client.register_chunk(target, &chunk).await.unwrap();
 
@@ -303,7 +303,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -360,7 +360,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -447,7 +447,7 @@ async fn test_level_filtering() {
             max_timestamp: ((i + 1) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }

--- a/tests/level_tracking_tests.rs
+++ b/tests/level_tracking_tests.rs
@@ -29,6 +29,7 @@ async fn test_new_chunks_start_at_l0() {
         max_timestamp: 1000,
         row_count: 1000,
         size_bytes: 1024 * 1024,
+        shard_id: 0,
     };
 
     metadata_client
@@ -74,6 +75,7 @@ async fn test_l0_to_l1_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -85,6 +87,7 @@ async fn test_l0_to_l1_progression() {
         max_timestamp: 3000,
         row_count: 3000,
         size_bytes: 3 * 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&l1_chunk.path, &l1_chunk)
@@ -144,6 +147,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: (i as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -154,6 +158,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 2000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&l1_chunk_1.path, &l1_chunk_1)
@@ -174,6 +179,7 @@ async fn test_l1_to_l2_progression() {
             max_timestamp: ((i + 2) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -184,6 +190,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 4000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&l1_chunk_2.path, &l1_chunk_2)
@@ -202,6 +209,7 @@ async fn test_l1_to_l2_progression() {
         max_timestamp: 4000,
         row_count: 4000,
         size_bytes: 4 * 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&l2_chunk.path, &l2_chunk)
@@ -274,6 +282,7 @@ async fn test_full_level_progression() {
             max_timestamp: max_ts,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         client.register_chunk(target, &chunk).await.unwrap();
 
@@ -294,6 +303,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -350,6 +360,7 @@ async fn test_full_level_progression() {
             max_timestamp: (i + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(&path, &chunk).await.unwrap();
     }
@@ -420,6 +431,7 @@ async fn test_level_filtering() {
         max_timestamp: 1000,
         row_count: 1000,
         size_bytes: 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&l0_chunk.path, &l0_chunk)
@@ -435,6 +447,7 @@ async fn test_level_filtering() {
             max_timestamp: ((i + 1) as i64 + 1) * 1000,
             row_count: 1000,
             size_bytes: 1024 * 1024,
+        shard_id: 0,
         };
         metadata_client.register_chunk(path, &chunk).await.unwrap();
     }
@@ -445,6 +458,7 @@ async fn test_level_filtering() {
         max_timestamp: 3000,
         row_count: 2000,
         size_bytes: 2 * 1024 * 1024,
+        shard_id: 0,
     };
     metadata_client
         .register_chunk(&l1_target.path, &l1_target)

--- a/tests/predicate_pushdown_tests.rs
+++ b/tests/predicate_pushdown_tests.rs
@@ -37,6 +37,7 @@ async fn register_chunk_with_stats(
         max_timestamp: max_ts,
         row_count: 1000,
         size_bytes: 100_000,
+        shard_id: 0,
     };
 
     client.register_chunk(path, &chunk).await.unwrap();

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -87,7 +87,7 @@ async fn test_phase2_dualwrite_state() {
 
     let shard = create_test_shard();
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
-    let split_point = vec![128u8; 8]; // Mid-point
+    let split_point = 0x8000u32.to_be_bytes().to_vec(); // Hash midpoint for range (0, 0x10000)
 
     // Start split (Phase 1-2)
     metadata
@@ -167,7 +167,7 @@ async fn test_phase3_backfill() {
 
     // Start split
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
-    let split_point = 3000i64.to_be_bytes().to_vec(); // Split at timestamp 3000
+    let split_point = 0x8000u32.to_be_bytes().to_vec(); // Hash midpoint
 
     metadata
         .start_split(
@@ -225,7 +225,7 @@ async fn test_phase4_cutover() {
         .await
         .unwrap();
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
-    let split_point = 5000i64.to_be_bytes().to_vec();
+    let split_point = 0x8000u32.to_be_bytes().to_vec();
 
     // Set up split state with 100% backfill
     metadata
@@ -291,7 +291,7 @@ async fn test_phase4_cutover_requires_old_shard_metadata() {
         .start_split(
             &shard.shard_id.to_string(),
             vec![shard_a, shard_b],
-            5000i64.to_be_bytes().to_vec(),
+            0x8000u32.to_be_bytes().to_vec(),
         )
         .await
         .unwrap();
@@ -324,7 +324,7 @@ async fn test_phase4_cutover_rejects_invalid_split_state_shape() {
         .start_split(
             &shard.shard_id.to_string(),
             vec!["only-one-new-shard".to_string()],
-            5000i64.to_be_bytes().to_vec(),
+            0x8000u32.to_be_bytes().to_vec(),
         )
         .await
         .unwrap();
@@ -544,7 +544,7 @@ async fn test_backfill_progress_tracking() {
     }
 
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
-    let split_point = 3000i64.to_be_bytes().to_vec();
+    let split_point = 0x8000u32.to_be_bytes().to_vec();
 
     metadata
         .start_split(
@@ -621,7 +621,7 @@ async fn test_backfill_rerun_is_idempotent() {
         .unwrap();
 
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
-    let split_point = 3000i64.to_be_bytes().to_vec();
+    let split_point = 0x8000u32.to_be_bytes().to_vec();
     metadata
         .start_split(
             &shard.shard_id.to_string(),
@@ -757,7 +757,7 @@ async fn test_backfill_resume_after_partial_failure() {
         .unwrap();
 
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
-    let split_point = 3000i64.to_be_bytes().to_vec();
+    let split_point = 0x8000u32.to_be_bytes().to_vec();
 
     metadata
         .start_split(

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -69,11 +69,13 @@ async fn test_phase1_preparation() {
     // Verify new shard IDs are generated
     assert_ne!(shard_a, shard_b, "New shards should have different IDs");
     assert_ne!(
-        shard_a, shard.shard_id.to_string(),
+        shard_a,
+        shard.shard_id.to_string(),
         "New shard A should be different from original"
     );
     assert_ne!(
-        shard_b, shard.shard_id.to_string(),
+        shard_b,
+        shard.shard_id.to_string(),
         "New shard B should be different from original"
     );
 }
@@ -246,7 +248,10 @@ async fn test_phase4_cutover() {
     splitter.cutover(&shard.shard_id.to_string()).await.unwrap();
 
     // Verify split is complete
-    let split_state = metadata.get_split_state(&shard.shard_id.to_string()).await.unwrap();
+    let split_state = metadata
+        .get_split_state(&shard.shard_id.to_string())
+        .await
+        .unwrap();
     assert!(
         split_state.is_none(),
         "Split state should be removed after cutover"
@@ -300,7 +305,10 @@ async fn test_phase4_cutover_requires_old_shard_metadata() {
         .await
         .unwrap();
 
-    let err = splitter.cutover(&shard.shard_id.to_string()).await.unwrap_err();
+    let err = splitter
+        .cutover(&shard.shard_id.to_string())
+        .await
+        .unwrap_err();
     assert!(
         matches!(err, cardinalsin::Error::ShardNotFound(ref id) if id == &shard.shard_id.to_string()),
         "expected ShardNotFound when old shard metadata is missing, got: {}",
@@ -333,7 +341,10 @@ async fn test_phase4_cutover_rejects_invalid_split_state_shape() {
         .await
         .unwrap();
 
-    let err = splitter.cutover(&shard.shard_id.to_string()).await.unwrap_err();
+    let err = splitter
+        .cutover(&shard.shard_id.to_string())
+        .await
+        .unwrap_err();
     assert!(
         matches!(err, cardinalsin::Error::Internal(ref msg) if msg.contains("expected 2 new shards")),
         "expected split-state shape validation error, got: {}",
@@ -372,7 +383,10 @@ async fn test_phase5_cleanup() {
 
     // Execute cleanup with short grace period
     splitter
-        .cleanup(&shard.shard_id.to_string(), std::time::Duration::from_millis(10))
+        .cleanup(
+            &shard.shard_id.to_string(),
+            std::time::Duration::from_millis(10),
+        )
         .await
         .unwrap();
 
@@ -448,7 +462,10 @@ async fn test_full_split_execution() {
     match result {
         Ok(_) => {
             // Split succeeded - verify split state is cleaned up
-            let split_state = metadata.get_split_state(&shard.shard_id.to_string()).await.unwrap();
+            let split_state = metadata
+                .get_split_state(&shard.shard_id.to_string())
+                .await
+                .unwrap();
             assert!(split_state.is_none(), "Split state should be cleaned up");
         }
         Err(e) => {
@@ -535,7 +552,7 @@ async fn test_backfill_progress_tracking() {
             max_timestamp: i * 1000 + 1000,
             row_count: 2,
             size_bytes: 1024,
-        shard_id: 0,
+            shard_id: 0,
         };
         metadata
             .register_chunk(&chunk_path, &chunk_meta)
@@ -557,7 +574,11 @@ async fn test_backfill_progress_tracking() {
 
     // Run backfill
     splitter
-        .run_backfill(&shard.shard_id.to_string(), &[shard_a, shard_b], &split_point)
+        .run_backfill(
+            &shard.shard_id.to_string(),
+            &[shard_a, shard_b],
+            &split_point,
+        )
         .await
         .unwrap();
 
@@ -614,7 +635,7 @@ async fn test_backfill_rerun_is_idempotent() {
                 max_timestamp: 5000,
                 row_count: 5,
                 size_bytes: 1024,
-        shard_id: 0,
+                shard_id: 0,
             },
         )
         .await
@@ -734,7 +755,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 2000,
                 row_count: 3,
                 size_bytes: 1024,
-        shard_id: 0,
+                shard_id: 0,
             },
         )
         .await
@@ -750,7 +771,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 5000,
                 row_count: 3,
                 size_bytes: 1024,
-        shard_id: 0,
+                shard_id: 0,
             },
         )
         .await

--- a/tests/shard_split_tests.rs
+++ b/tests/shard_split_tests.rs
@@ -16,7 +16,8 @@ use std::sync::Arc;
 /// Helper to create a test shard
 fn create_test_shard() -> ShardMetadata {
     ShardMetadata {
-        shard_id: "test-shard-1".to_string(),
+        shard_id: 1,
+        hash_range: (0, 0x10000),
         generation: 1,
         key_range: (vec![0u8; 8], vec![255u8; 8]),
         replicas: vec![ReplicaInfo {
@@ -68,11 +69,11 @@ async fn test_phase1_preparation() {
     // Verify new shard IDs are generated
     assert_ne!(shard_a, shard_b, "New shards should have different IDs");
     assert_ne!(
-        shard_a, shard.shard_id,
+        shard_a, shard.shard_id.to_string(),
         "New shard A should be different from original"
     );
     assert_ne!(
-        shard_b, shard.shard_id,
+        shard_b, shard.shard_id.to_string(),
         "New shard B should be different from original"
     );
 }
@@ -91,7 +92,7 @@ async fn test_phase2_dualwrite_state() {
     // Start split (Phase 1-2)
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a.clone(), shard_b.clone()],
             split_point.clone(),
         )
@@ -99,19 +100,19 @@ async fn test_phase2_dualwrite_state() {
         .unwrap();
 
     metadata
-        .update_split_progress(&shard.shard_id, 0.0, SplitPhase::DualWrite)
+        .update_split_progress(&shard.shard_id.to_string(), 0.0, SplitPhase::DualWrite)
         .await
         .unwrap();
 
     // Verify split state
     let split_state = metadata
-        .get_split_state(&shard.shard_id)
+        .get_split_state(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Split state should exist");
 
     assert_eq!(split_state.phase, SplitPhase::DualWrite);
-    assert_eq!(split_state.old_shard, shard.shard_id);
+    assert_eq!(split_state.old_shard, shard.shard_id.to_string());
     assert_eq!(split_state.new_shards.len(), 2);
     assert_eq!(split_state.split_point, split_point);
 }
@@ -157,6 +158,7 @@ async fn test_phase3_backfill() {
         max_timestamp: 5000,
         row_count: 5,
         size_bytes: 1024,
+        shard_id: 0,
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -169,7 +171,7 @@ async fn test_phase3_backfill() {
 
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a.clone(), shard_b.clone()],
             split_point.clone(),
         )
@@ -179,7 +181,7 @@ async fn test_phase3_backfill() {
     // Run backfill
     splitter
         .run_backfill(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             &[shard_a.clone(), shard_b.clone()],
             &split_point,
         )
@@ -188,7 +190,7 @@ async fn test_phase3_backfill() {
 
     // Verify split progress is complete
     let split_state = metadata
-        .get_split_state(&shard.shard_id)
+        .get_split_state(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Split state should exist");
@@ -219,7 +221,7 @@ async fn test_phase4_cutover() {
 
     let shard = create_test_shard();
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
     let (shard_a, shard_b) = splitter.split_shard(&shard).await.unwrap();
@@ -228,7 +230,7 @@ async fn test_phase4_cutover() {
     // Set up split state with 100% backfill
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a.clone(), shard_b.clone()],
             split_point,
         )
@@ -236,15 +238,15 @@ async fn test_phase4_cutover() {
         .unwrap();
 
     metadata
-        .update_split_progress(&shard.shard_id, 1.0, SplitPhase::Backfill)
+        .update_split_progress(&shard.shard_id.to_string(), 1.0, SplitPhase::Backfill)
         .await
         .unwrap();
 
     // Execute cutover
-    splitter.cutover(&shard.shard_id).await.unwrap();
+    splitter.cutover(&shard.shard_id.to_string()).await.unwrap();
 
     // Verify split is complete
-    let split_state = metadata.get_split_state(&shard.shard_id).await.unwrap();
+    let split_state = metadata.get_split_state(&shard.shard_id.to_string()).await.unwrap();
     assert!(
         split_state.is_none(),
         "Split state should be removed after cutover"
@@ -252,7 +254,7 @@ async fn test_phase4_cutover() {
 
     // Verify old shard is fenced from new writes and new shards are active
     let old = metadata
-        .get_shard_metadata(&shard.shard_id)
+        .get_shard_metadata(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("old shard metadata should exist");
@@ -287,20 +289,20 @@ async fn test_phase4_cutover_requires_old_shard_metadata() {
 
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a, shard_b],
             5000i64.to_be_bytes().to_vec(),
         )
         .await
         .unwrap();
     metadata
-        .update_split_progress(&shard.shard_id, 1.0, SplitPhase::Backfill)
+        .update_split_progress(&shard.shard_id.to_string(), 1.0, SplitPhase::Backfill)
         .await
         .unwrap();
 
-    let err = splitter.cutover(&shard.shard_id).await.unwrap_err();
+    let err = splitter.cutover(&shard.shard_id.to_string()).await.unwrap_err();
     assert!(
-        matches!(err, cardinalsin::Error::ShardNotFound(ref id) if id == &shard.shard_id),
+        matches!(err, cardinalsin::Error::ShardNotFound(ref id) if id == &shard.shard_id.to_string()),
         "expected ShardNotFound when old shard metadata is missing, got: {}",
         err
     );
@@ -314,24 +316,24 @@ async fn test_phase4_cutover_rejects_invalid_split_state_shape() {
 
     let shard = create_test_shard();
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec!["only-one-new-shard".to_string()],
             5000i64.to_be_bytes().to_vec(),
         )
         .await
         .unwrap();
     metadata
-        .update_split_progress(&shard.shard_id, 1.0, SplitPhase::Backfill)
+        .update_split_progress(&shard.shard_id.to_string(), 1.0, SplitPhase::Backfill)
         .await
         .unwrap();
 
-    let err = splitter.cutover(&shard.shard_id).await.unwrap_err();
+    let err = splitter.cutover(&shard.shard_id.to_string()).await.unwrap_err();
     assert!(
         matches!(err, cardinalsin::Error::Internal(ref msg) if msg.contains("expected 2 new shards")),
         "expected split-state shape validation error, got: {}",
@@ -361,6 +363,7 @@ async fn test_phase5_cleanup() {
         max_timestamp: 1000,
         row_count: 100,
         size_bytes: 1024,
+        shard_id: 0,
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -369,7 +372,7 @@ async fn test_phase5_cleanup() {
 
     // Execute cleanup with short grace period
     splitter
-        .cleanup(&shard.shard_id, std::time::Duration::from_millis(10))
+        .cleanup(&shard.shard_id.to_string(), std::time::Duration::from_millis(10))
         .await
         .unwrap();
 
@@ -396,7 +399,7 @@ async fn test_full_split_execution() {
 
     // Store shard metadata for CAS operations
     metadata
-        .update_shard_metadata(&shard.shard_id, &shard, 0)
+        .update_shard_metadata(&shard.shard_id.to_string(), &shard, 0)
         .await
         .unwrap();
 
@@ -430,6 +433,7 @@ async fn test_full_split_execution() {
         max_timestamp: 4000,
         row_count: 4,
         size_bytes: 1024,
+        shard_id: 0,
     };
     metadata
         .register_chunk(&chunk_path, &chunk_meta)
@@ -444,7 +448,7 @@ async fn test_full_split_execution() {
     match result {
         Ok(_) => {
             // Split succeeded - verify split state is cleaned up
-            let split_state = metadata.get_split_state(&shard.shard_id).await.unwrap();
+            let split_state = metadata.get_split_state(&shard.shard_id.to_string()).await.unwrap();
             assert!(split_state.is_none(), "Split state should be cleaned up");
         }
         Err(e) => {
@@ -467,7 +471,8 @@ async fn test_split_point_calculation() {
     let splitter = ShardSplitter::new(metadata.clone(), object_store);
 
     let shard = ShardMetadata {
-        shard_id: "test-shard".to_string(),
+        shard_id: 99,
+        hash_range: (0, 0x10000),
         generation: 1,
         key_range: (vec![0u8; 8], vec![255u8; 8]),
         replicas: vec![],
@@ -530,6 +535,7 @@ async fn test_backfill_progress_tracking() {
             max_timestamp: i * 1000 + 1000,
             row_count: 2,
             size_bytes: 1024,
+        shard_id: 0,
         };
         metadata
             .register_chunk(&chunk_path, &chunk_meta)
@@ -542,7 +548,7 @@ async fn test_backfill_progress_tracking() {
 
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a.clone(), shard_b.clone()],
             split_point.clone(),
         )
@@ -551,13 +557,13 @@ async fn test_backfill_progress_tracking() {
 
     // Run backfill
     splitter
-        .run_backfill(&shard.shard_id, &[shard_a, shard_b], &split_point)
+        .run_backfill(&shard.shard_id.to_string(), &[shard_a, shard_b], &split_point)
         .await
         .unwrap();
 
     // Verify final progress is 100%
     let split_state = metadata
-        .get_split_state(&shard.shard_id)
+        .get_split_state(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Split state should exist");
@@ -608,6 +614,7 @@ async fn test_backfill_rerun_is_idempotent() {
                 max_timestamp: 5000,
                 row_count: 5,
                 size_bytes: 1024,
+        shard_id: 0,
             },
         )
         .await
@@ -617,7 +624,7 @@ async fn test_backfill_rerun_is_idempotent() {
     let split_point = 3000i64.to_be_bytes().to_vec();
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a.clone(), shard_b.clone()],
             split_point.clone(),
         )
@@ -626,7 +633,7 @@ async fn test_backfill_rerun_is_idempotent() {
 
     splitter
         .run_backfill(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             &[shard_a.clone(), shard_b.clone()],
             &split_point,
         )
@@ -638,7 +645,7 @@ async fn test_backfill_rerun_is_idempotent() {
 
     splitter
         .run_backfill(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             &[shard_a.clone(), shard_b.clone()],
             &split_point,
         )
@@ -675,7 +682,7 @@ async fn test_backfill_rerun_is_idempotent() {
     );
 
     let split_state = metadata
-        .get_split_state(&shard.shard_id)
+        .get_split_state(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("Split state should exist");
@@ -727,6 +734,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 2000,
                 row_count: 3,
                 size_bytes: 1024,
+        shard_id: 0,
             },
         )
         .await
@@ -742,6 +750,7 @@ async fn test_backfill_resume_after_partial_failure() {
                 max_timestamp: 5000,
                 row_count: 3,
                 size_bytes: 1024,
+        shard_id: 0,
             },
         )
         .await
@@ -752,7 +761,7 @@ async fn test_backfill_resume_after_partial_failure() {
 
     metadata
         .start_split(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             vec![shard_a.clone(), shard_b.clone()],
             split_point.clone(),
         )
@@ -761,7 +770,7 @@ async fn test_backfill_resume_after_partial_failure() {
 
     let first_attempt = splitter
         .run_backfill(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             &[shard_a.clone(), shard_b.clone()],
             &split_point,
         )
@@ -772,7 +781,7 @@ async fn test_backfill_resume_after_partial_failure() {
     );
 
     let partial_progress = splitter
-        .load_progress(&shard.shard_id)
+        .load_progress(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("progress should be persisted after partial failure");
@@ -789,7 +798,7 @@ async fn test_backfill_resume_after_partial_failure() {
 
     splitter
         .run_backfill(
-            &shard.shard_id,
+            &shard.shard_id.to_string(),
             &[shard_a.clone(), shard_b.clone()],
             &split_point,
         )
@@ -797,7 +806,7 @@ async fn test_backfill_resume_after_partial_failure() {
         .unwrap();
 
     let complete_progress = splitter
-        .load_progress(&shard.shard_id)
+        .load_progress(&shard.shard_id.to_string())
         .await
         .unwrap()
         .expect("progress should still exist before cleanup phase");

--- a/tests/sharding_orchestration_test.rs
+++ b/tests/sharding_orchestration_test.rs
@@ -2,7 +2,9 @@
 
 use cardinalsin::compactor::{Compactor, CompactorConfig};
 use cardinalsin::metadata::{LocalMetadataClient, MetadataClient};
-use cardinalsin::sharding::{HotShardConfig, ReplicaInfo, ShardId, ShardMetadata, ShardMonitor, ShardState};
+use cardinalsin::sharding::{
+    HotShardConfig, ReplicaInfo, ShardId, ShardMetadata, ShardMonitor, ShardState,
+};
 use cardinalsin::StorageConfig;
 use object_store::memory::InMemory;
 use object_store::ObjectStore;
@@ -74,7 +76,8 @@ async fn setup_test_env() -> (
 
 #[tokio::test]
 async fn test_compactor_triggers_shard_split() {
-    let (compactor, metadata, shard_monitor, hot_shard_id, hot_shard_numeric) = setup_test_env().await;
+    let (compactor, metadata, shard_monitor, hot_shard_id, hot_shard_numeric) =
+        setup_test_env().await;
 
     // Simulate high write traffic to the hot shard.
     // The monitor requires one evaluation to mark hot, then another after the

--- a/tests/sharding_orchestration_test.rs
+++ b/tests/sharding_orchestration_test.rs
@@ -2,7 +2,7 @@
 
 use cardinalsin::compactor::{Compactor, CompactorConfig};
 use cardinalsin::metadata::{LocalMetadataClient, MetadataClient};
-use cardinalsin::sharding::{HotShardConfig, ReplicaInfo, ShardMetadata, ShardMonitor, ShardState};
+use cardinalsin::sharding::{HotShardConfig, ReplicaInfo, ShardId, ShardMetadata, ShardMonitor, ShardState};
 use cardinalsin::StorageConfig;
 use object_store::memory::InMemory;
 use object_store::ObjectStore;
@@ -10,12 +10,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 /// Sets up a test environment with a compactor and its dependencies.
-/// Returns the compactor, metadata client, shard monitor, and the ID of an initial shard.
+/// Returns the compactor, metadata client, shard monitor, the string key and numeric ShardId.
 async fn setup_test_env() -> (
     Arc<Compactor>,
     Arc<dyn MetadataClient>,
     Arc<ShardMonitor>,
     String,
+    ShardId,
 ) {
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let metadata: Arc<dyn MetadataClient> = Arc::new(LocalMetadataClient::new());
@@ -45,9 +46,13 @@ async fn setup_test_env() -> (
     ));
 
     // Create an initial shard to be split
-    let initial_shard_id = "shard-hot".to_string();
+    // Use the numeric shard_id as the metadata key so the compactor can find it
+    // via shard_id.to_string() after ShardAction::Split(shard_id)
+    let numeric_shard_id: ShardId = 100;
+    let initial_shard_id = numeric_shard_id.to_string();
     let initial_shard = ShardMetadata {
-        shard_id: initial_shard_id.clone(),
+        shard_id: numeric_shard_id,
+        hash_range: (0, 0x10000),
         generation: 1,
         key_range: (vec![], vec![]), // Simplified for test
         replicas: vec![ReplicaInfo {
@@ -64,18 +69,18 @@ async fn setup_test_env() -> (
         .await
         .unwrap();
 
-    (compactor, metadata, shard_monitor, initial_shard_id)
+    (compactor, metadata, shard_monitor, initial_shard_id, 100)
 }
 
 #[tokio::test]
 async fn test_compactor_triggers_shard_split() {
-    let (compactor, metadata, shard_monitor, hot_shard_id) = setup_test_env().await;
+    let (compactor, metadata, shard_monitor, hot_shard_id, hot_shard_numeric) = setup_test_env().await;
 
     // Simulate high write traffic to the hot shard.
     // The monitor requires one evaluation to mark hot, then another after the
     // detection window to trigger a split action.
     for _ in 0..20 {
-        shard_monitor.record_write(&hot_shard_id, 500, Duration::from_millis(10));
+        shard_monitor.record_write(&hot_shard_numeric, 500, Duration::from_millis(10));
     }
 
     // First cycle marks the shard as hot (no split yet).
@@ -84,7 +89,7 @@ async fn test_compactor_triggers_shard_split() {
     // Keep the shard hot across the detection window, then evaluate again.
     tokio::time::sleep(Duration::from_secs(2)).await;
     for _ in 0..20 {
-        shard_monitor.record_write(&hot_shard_id, 500, Duration::from_millis(10));
+        shard_monitor.record_write(&hot_shard_numeric, 500, Duration::from_millis(10));
     }
 
     // Second cycle should now trigger split orchestration.


### PR DESCRIPTION
## Summary

Implements the shard-aware data paths from Issues #171-#177 (excluding #173 distributed routing). Establishes one authoritative shard model across writes, metadata, queries, and splits.

**Shard model**: Hybrid fixed + auto-split with `metric_hash` (xxhash64 → u16) as the shard key. Initial layout: N fixed shards covering the 16-bit hash space. Auto-split divides at hash midpoint.

### Commits (4):

1. **ShardId = u32 + hash-based routing** — Replace string shard IDs with compact `ShardId = u32`. Add `hash_metric_name()` (xxhash64 seed 0), `find_shard_for_hash()`, `initial_shards()`. Propagate through all 21 files.

2. **Per-shard write buffers** — Replace single `WriteBuffer` with `HashMap<ShardId, WriteBuffer>`. Vectorized `partition_batch_by_shard()` routes rows by metric hash with zero I/O. Shard-qualified S3 paths (`shard={id}/year=.../chunk.parquet`). WAL truncation only when ALL buffers empty. `write_pre_partitioned()` API for future routing. `refresh_shard_ranges()` for split events.

3. **Query shard pruning** — `candidate_shard_ids()` extracts exact `metric_name` predicates (Eq, In), hashes them, returns matching shards. Wired into `query_for_tenant()` to use `get_chunks_for_shards()` when pruning applies.

4. **Hash-based split protocol** — Split point = hash range midpoint (u32) instead of timestamp. `split_batch()` partitions by `hash_metric_name()`. Child shards get correct hash sub-ranges.

## Test plan

- [x] All 319 tests pass (313 existing + 6 new planner unit tests)
- [ ] CI runs full test suite
- [ ] Verify shard-qualified paths in E2E docker-compose test

Refs: #171, #172, #174, #175, #176, #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)